### PR TITLE
🪟 fix: Correctly Resolve Windows Path

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,5 @@
-import { join } from 'node:path';
 import { Glob } from 'bun';
+import { join } from 'node:path';
 
 const CLIENT_DIR = join(import.meta.dir, 'dist', 'client');
 const SERVER_ENTRY = new URL('./dist/server/server.js', import.meta.url);

--- a/server.ts
+++ b/server.ts
@@ -1,7 +1,7 @@
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { Glob } from 'bun';
 
-const CLIENT_DIR = fileURLToPath(new URL('./dist/client', import.meta.url));
+const CLIENT_DIR = join(import.meta.dir, 'dist', 'client');
 const SERVER_ENTRY = new URL('./dist/server/server.js', import.meta.url);
 
 type Handler = { default: { fetch: (req: Request) => Promise<Response> } };

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,7 @@
+import { fileURLToPath } from 'node:url';
 import { Glob } from 'bun';
 
-const CLIENT_DIR = new URL('./dist/client', import.meta.url).pathname;
+const CLIENT_DIR = fileURLToPath(new URL('./dist/client', import.meta.url));
 const SERVER_ENTRY = new URL('./dist/server/server.js', import.meta.url);
 
 type Handler = { default: { fetch: (req: Request) => Promise<Response> } };


### PR DESCRIPTION
## Summary
- `new URL(...).pathname` produces `/C:/...` on Windows, which is invalid for filesystem APIs like `Glob.scan()`, causing `ENOENT`
- Replaced with `fileURLToPath()` from `node:url`, which correctly converts `file:///C:/...` to `C:\...` on Windows (no-op difference on Unix)
- `SERVER_ENTRY` is unchanged since it's passed to `import()` which accepts URLs

## Test plan
- [x] Verify `bun run start` works on Windows without ENOENT from `Glob.scan()`
- [x] Verify production build still serves static assets on Linux/macOS