### PR TITLE
🖱️ fix: Role and Group Scroll Areas

### DIFF
--- a/src/components/access/AccessPage.tsx
+++ b/src/components/access/AccessPage.tsx
@@ -34,7 +34,7 @@ export function AccessPage({
         </Tabs>
       )}
 
-      <div className="min-h-0 flex-1 overflow-hidden pt-3">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden pt-3">
         {activeTab === 'groups' && canReadGroups && (
           <GroupsTab onCreateGroup={() => setCreateGroupOpen(true)} />
         )}


### PR DESCRIPTION
## Summary

The roles/groups tab content wrapper was not a flex container, so child flex-1 constraints were ignored and overflow-y-auto never triggered, and so the list was clipped with no scrollbar.

- **UI/Layout Improvement:**
  * Updated the main content `div` in `AccessPage.tsx` to use `flex-col` for better vertical layout handling.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before

https://github.com/user-attachments/assets/cf7c7e7c-215d-44ef-a86e-3c0bd0399721

### After 

https://github.com/user-attachments/assets/17e75bbb-636e-465a-b56a-7fd040adec14

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes