### PR TITLE
🛝 fix: Render Sidebar Text

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -83,15 +83,11 @@ export function Sidebar({ user, collapsed, onToggle }: t.SidebarProps) {
         )}
       >
         <div className="flex h-14 shrink-0 items-center px-2">
-          <div
-            className={cn('flex items-center', collapsed ? 'w-9 justify-center' : 'gap-2.5 px-1.5')}
-          >
+          <div className="flex items-center gap-2.5 overflow-hidden px-1.5">
             <img src={libreChatLogo} alt="LibreChat" className="h-6 w-6 shrink-0" />
-            {!collapsed && (
-              <span className="flex-1 truncate text-sm font-semibold text-(--cui-color-text-default)">
-                Admin Panel
-              </span>
-            )}
+            <span className="truncate text-sm font-semibold text-(--cui-color-text-default)">
+              Admin Panel
+            </span>
           </div>
         </div>
 
@@ -105,8 +101,7 @@ export function Sidebar({ user, collapsed, onToggle }: t.SidebarProps) {
                 aria-label={collapsed ? localize(item.labelKey) : undefined}
                 title={collapsed ? localize(item.labelKey) : undefined}
                 className={cn(
-                  'flex h-8 items-center rounded-md text-sm no-underline transition-colors duration-100',
-                  collapsed ? 'w-9 justify-center' : 'gap-2.5 px-2.5',
+                  'flex h-8 items-center gap-2.5 overflow-hidden rounded-md px-2.5 text-sm whitespace-nowrap no-underline transition-colors duration-100',
                   isActive(item.path)
                     ? 'bg-(--cui-color-background-active) font-medium text-(--cui-color-text-default)'
                     : 'font-normal text-(--cui-color-text-muted) hover:bg-(--cui-color-background-hover) hover:text-(--cui-color-text-default)',
@@ -115,7 +110,7 @@ export function Sidebar({ user, collapsed, onToggle }: t.SidebarProps) {
                 <span aria-hidden="true" className="shrink-0">
                   <Icon name={item.icon} size="sm" />
                 </span>
-                {!collapsed && <span className="truncate text-sm">{localize(item.labelKey)}</span>}
+                <span className="truncate text-sm">{localize(item.labelKey)}</span>
               </Link>
             ))}
           </div>
@@ -123,12 +118,7 @@ export function Sidebar({ user, collapsed, onToggle }: t.SidebarProps) {
 
         {initials && (
           <div className="flex shrink-0 items-center border-t border-(--cui-color-stroke-default) px-2 py-3">
-            <div
-              className={cn(
-                'flex items-center',
-                collapsed ? 'w-9 justify-center' : 'gap-2.5 px-0.5',
-              )}
-            >
+            <div className="flex items-center gap-2.5 overflow-hidden px-0.5">
               <Dropdown>
                 <Dropdown.Trigger>
                   <button
@@ -171,7 +161,7 @@ export function Sidebar({ user, collapsed, onToggle }: t.SidebarProps) {
                   </div>
                 </Dropdown.Content>
               </Dropdown>
-              {!collapsed && user && (
+              {user && (
                 <div className="min-w-0 flex-1">
                   <span className="block truncate text-sm leading-tight font-medium text-(--cui-color-text-default)">
                     {user.name || ''}


### PR DESCRIPTION
# Pull Request Template

## Summary

Text labels were conditionally mounted/unmounted with collapsed state, causing a visible pop-in. Now text is always in the DOM and clipped via overflow-hidden, sliding smoothly into view as the sidebar widens.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before

https://github.com/user-attachments/assets/b3dc56c3-e71c-4bc2-b553-aeb670046f6c

### After

https://github.com/user-attachments/assets/1acde29c-5e16-4168-b760-345241769d0f

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes