### PR TITLE
👆 fix: Widen Click Area on Capability Panel Headers

### DIFF
--- a/src/components/grants/CapabilityPanel.tsx
+++ b/src/components/grants/CapabilityPanel.tsx
@@ -73,17 +73,22 @@ export function CapabilityPanel({ capabilities, onChange, disabled }: t.Capabili
         return (
           <div key={category.key} className="rounded-lg border border-(--cui-color-stroke-default)">
             <div
+              role="button"
+              tabIndex={0}
+              aria-expanded={isOpen}
+              onClick={() => toggleCollapsed(category.key)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  toggleCollapsed(category.key);
+                }
+              }}
               className={cn(
-                'flex w-full items-center justify-between px-4 py-3 transition-colors',
+                'flex w-full cursor-pointer items-center justify-between px-4 py-3 transition-colors hover:bg-(--cui-color-background-hover) focus-visible:bg-(--cui-color-background-hover) focus-visible:outline-1 focus-visible:outline-(--cui-color-outline)',
                 isOpen ? 'rounded-t-lg' : 'rounded-lg',
               )}
             >
-              <button
-                type="button"
-                onClick={() => toggleCollapsed(category.key)}
-                aria-expanded={isOpen}
-                className="flex items-center gap-2 text-left hover:opacity-80"
-              >
+              <div className="flex flex-1 items-center gap-2">
                 <Icon
                   name="chevron-right"
                   size="sm"
@@ -95,8 +100,8 @@ export function CapabilityPanel({ capabilities, onChange, disabled }: t.Capabili
                 <span className="text-sm font-medium text-(--cui-color-text-default)">
                   {localize(category.labelKey)}
                 </span>
-              </button>
-              <div className="flex items-center gap-3">
+              </div>
+              <div className="flex items-center gap-3" onClick={(e) => e.stopPropagation()}>
                 <span className="text-xs text-(--cui-color-text-muted)">
                   {allEnabled ? localize('com_ui_all') : `${enabledCount}/${caps.length}`}
                 </span>


### PR DESCRIPTION
## Summary

The expand/collapse target on capability panel section headers was limited to just the chevron icon and label text — a small hit area that made toggling sections frustrating.

Now the entire header row is clickable for expand/collapse, with hover and focus-visible styles. The toggle-all switch on the right uses `stopPropagation` to avoid conflicts. This matches the pattern already used in `RolePermissionsPanel`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Open the **Grants** page → click any principal to open the Edit Capabilities dialog
2. Verify clicking anywhere on a category header row (not just the icon/text) expands/collapses it
3. Verify the toggle-all switch still works independently without triggering expand/collapse
4. Verify keyboard navigation works (Tab to header, Enter/Space to toggle)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes