### PR TITLE
🔒 fix: Read-Only Edit Dialogs Without Manage Permission

### DIFF
--- a/src/components/access/EditGroupDialog.tsx
+++ b/src/components/access/EditGroupDialog.tsx
@@ -162,8 +162,10 @@ export function EditGroupDialog({ group, canManage, onClose }: t.EditGroupDialog
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     placeholder={localize('com_access_group_name_placeholder')}
+                    disabled={!canManage}
+                    readOnly={!canManage}
                     autoFocus
-                    className="rounded-lg border border-(--cui-color-stroke-default) bg-(--cui-color-background-default) px-3 py-2 text-sm text-(--cui-color-text-default) placeholder:text-(--cui-color-text-disabled)"
+                    className="rounded-lg border border-(--cui-color-stroke-default) bg-(--cui-color-background-default) px-3 py-2 text-sm text-(--cui-color-text-default) placeholder:text-(--cui-color-text-disabled) disabled:cursor-not-allowed disabled:opacity-50"
                   />
                 </div>
                 <div className="flex flex-col gap-1.5">
@@ -179,7 +181,9 @@ export function EditGroupDialog({ group, canManage, onClose }: t.EditGroupDialog
                     value={description}
                     onChange={(e) => setDescription(e.target.value)}
                     placeholder={localize('com_access_group_desc_placeholder')}
-                    className="rounded-lg border border-(--cui-color-stroke-default) bg-(--cui-color-background-default) px-3 py-2 text-sm text-(--cui-color-text-default) placeholder:text-(--cui-color-text-disabled)"
+                    disabled={!canManage}
+                    readOnly={!canManage}
+                    className="rounded-lg border border-(--cui-color-stroke-default) bg-(--cui-color-background-default) px-3 py-2 text-sm text-(--cui-color-text-default) placeholder:text-(--cui-color-text-disabled) disabled:cursor-not-allowed disabled:opacity-50"
                   />
                 </div>
               </div>
@@ -250,7 +254,7 @@ export function EditGroupDialog({ group, canManage, onClose }: t.EditGroupDialog
             <Button
               type="primary"
               label={localize('com_ui_save')}
-              disabled={!name.trim() || (!detailsDirty && !membersDirty) || mutation.isPending}
+              disabled={!canManage || !name.trim() || (!detailsDirty && !membersDirty) || mutation.isPending}
             />
           </div>
         </form>

--- a/src/components/access/EditRoleDialog.tsx
+++ b/src/components/access/EditRoleDialog.tsx
@@ -213,7 +213,8 @@ export function EditRoleDialog({ role, canManage, onClose }: t.EditRoleDialogPro
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     placeholder={localize('com_access_role_name_placeholder')}
-                    disabled={role?.isSystemRole}
+                    disabled={role?.isSystemRole || !canManage}
+                    readOnly={!canManage}
                     autoFocus
                     className="rounded-lg border border-(--cui-color-stroke-default) bg-(--cui-color-background-default) px-3 py-2 text-sm text-(--cui-color-text-default) placeholder:text-(--cui-color-text-disabled) disabled:cursor-not-allowed disabled:opacity-50"
                   />
@@ -231,7 +232,9 @@ export function EditRoleDialog({ role, canManage, onClose }: t.EditRoleDialogPro
                     value={description}
                     onChange={(e) => setDescription(e.target.value)}
                     placeholder={localize('com_access_role_desc_placeholder')}
-                    className="rounded-lg border border-(--cui-color-stroke-default) bg-(--cui-color-background-default) px-3 py-2 text-sm text-(--cui-color-text-default) placeholder:text-(--cui-color-text-disabled)"
+                    disabled={!canManage}
+                    readOnly={!canManage}
+                    className="rounded-lg border border-(--cui-color-stroke-default) bg-(--cui-color-background-default) px-3 py-2 text-sm text-(--cui-color-text-default) placeholder:text-(--cui-color-text-disabled) disabled:cursor-not-allowed disabled:opacity-50"
                   />
                 </div>
               </div>
@@ -260,7 +263,7 @@ export function EditRoleDialog({ role, canManage, onClose }: t.EditRoleDialogPro
                     <RolePermissionsPanel
                       permissions={permissions}
                       onChange={setPermissions}
-                      disabled={updateMutation.isPending}
+                      disabled={!canManage || updateMutation.isPending}
                     />
                   );
                 })()}
@@ -333,6 +336,7 @@ export function EditRoleDialog({ role, canManage, onClose }: t.EditRoleDialogPro
               type="primary"
               label={localize('com_ui_save')}
               disabled={
+                !canManage ||
                 !name.trim() ||
                 (permissionsDirty && permissions === null) ||
                 (!detailsDirty && !permissionsDirty && !membersDirty) ||


### PR DESCRIPTION
## Summary

When a user lacks `MANAGE_ROLES` or `MANAGE_GROUPS` capability, the edit role/group dialogs still allowed interacting with name and description fields, permission toggles, and the save button. This was misleading — the server would reject the mutation, but the UI didn't communicate that the user couldn't make changes.

Now when `!canManage`:
- Name and description text fields are `disabled` + `readOnly`
- Role permission toggles are disabled
- Save button is disabled
- Member add/remove controls were already correctly hidden (no change needed)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Log in as a user with `MANAGE_ROLES` / `MANAGE_GROUPS` → open an edit dialog → confirm fields are editable and save works
2. Remove `MANAGE_ROLES` grant from the user's role → refresh → open a role edit dialog → confirm:
   - Name and description inputs show `cursor-not-allowed` and can't be typed into
   - Permission toggles are non-interactive
   - Save button is greyed out / disabled
3. Repeat step 2 for groups with `MANAGE_GROUPS`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes