### PR TITLE
☸️ feat: Add API_SERVER_URL for separate server-side and browser API URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,13 @@
 SESSION_SECRET=
 
 # ── Optional ─────────────────────────────────────────────────
-# Base URL of the LibreChat API server. Defaults to http://localhost:3080
+# Browser-facing URL of the LibreChat API server (used for OAuth redirects).
+# Defaults to http://localhost:3080
 # VITE_API_BASE_URL=http://localhost:3080
+
+# Server-side URL for LibreChat API calls. Falls back to VITE_API_BASE_URL.
+# Useful when the server reaches LibreChat on a different URL than the browser.
+# API_SERVER_URL=http://localhost:3080
 
 # Force SSO-only login (hides the email/password form)
 # ADMIN_SSO_ONLY=false

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -7,7 +7,7 @@ import { createServerFn } from '@tanstack/react-start';
 import { getRequestHeader } from '@tanstack/react-start/server';
 import type * as t from '@/types';
 import { useAppSession, SESSION_CONFIG } from './session';
-import { getApiBaseUrl } from './utils/api';
+import { getApiBaseUrl, getServerApiUrl } from './utils/api';
 
 /** Extract a named cookie value from `set-cookie` response headers. */
 function extractCookieValue(response: Response, name: string): string | undefined {
@@ -29,7 +29,7 @@ export const adminLoginFn = createServerFn({ method: 'POST' })
   )
   .handler(async ({ data }) => {
     try {
-      const response = await fetch(`${getApiBaseUrl()}/api/admin/login/local`, {
+      const response = await fetch(`${getServerApiUrl()}/api/admin/login/local`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
@@ -93,7 +93,7 @@ export const adminVerify2FAFn = createServerFn({ method: 'POST' })
   )
   .handler(async ({ data }) => {
     try {
-      const response = await fetch(`${getApiBaseUrl()}/api/auth/2fa/verify-temp`, {
+      const response = await fetch(`${getServerApiUrl()}/api/auth/2fa/verify-temp`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tempToken: data.tempToken, token: data.totpCode }),
@@ -170,7 +170,7 @@ async function refreshAdminToken(
       cookieParts.push('token_provider=openid');
     }
 
-    const response = await fetch(`${getApiBaseUrl()}/api/auth/refresh`, {
+    const response = await fetch(`${getServerApiUrl()}/api/auth/refresh`, {
       method: 'POST',
       headers: { Cookie: cookieParts.join('; ') },
     });
@@ -216,7 +216,7 @@ export const verifyAdminTokenFn = createServerFn({ method: 'GET' }).handler(asyn
 
     if (needsRevalidation) {
       try {
-        const response = await fetch(`${getApiBaseUrl()}/api/admin/verify`, {
+        const response = await fetch(`${getServerApiUrl()}/api/admin/verify`, {
           headers: { Authorization: `Bearer ${token}` },
         });
 
@@ -236,7 +236,7 @@ export const verifyAdminTokenFn = createServerFn({ method: 'GET' }).handler(asyn
                   lastActivity: now,
                 };
                 try {
-                  const reVerify = await fetch(`${getApiBaseUrl()}/api/admin/verify`, {
+                  const reVerify = await fetch(`${getServerApiUrl()}/api/admin/verify`, {
                     headers: { Authorization: `Bearer ${refreshed.token}` },
                   });
                   if (reVerify.ok) {
@@ -305,7 +305,7 @@ export const adminLogoutFn = createServerFn({ method: 'POST' }).handler(async ()
 
     if (token) {
       try {
-        await fetch(`${getApiBaseUrl()}/api/auth/logout`, {
+        await fetch(`${getServerApiUrl()}/api/auth/logout`, {
           method: 'POST',
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -340,7 +340,7 @@ export const openIdCheckOptions = queryOptions({
 
 export const checkOpenIdFn = createServerFn({ method: 'GET' }).handler(async () => {
   try {
-    const response = await fetch(`${getApiBaseUrl()}/api/admin/oauth/openid/check`);
+    const response = await fetch(`${getServerApiUrl()}/api/admin/oauth/openid/check`);
     if (!response.ok) return { available: false, ssoOnly: false };
     const ssoOnly = process.env.ADMIN_SSO_ONLY === 'true';
     return { available: true, ssoOnly };
@@ -389,7 +389,7 @@ export const oauthExchangeFn = createServerFn({ method: 'POST' })
       const session = await useAppSession();
       const { codeVerifier } = session.data;
 
-      const response = await fetch(`${getApiBaseUrl()}/api/admin/oauth/exchange`, {
+      const response = await fetch(`${getServerApiUrl()}/api/admin/oauth/exchange`, {
         method: 'POST',
         headers,
         body: JSON.stringify({ code: data.code, code_verifier: codeVerifier }),

--- a/src/server/utils/api.ts
+++ b/src/server/utils/api.ts
@@ -10,6 +10,14 @@ export function getApiBaseUrl(): string {
   return 'http://localhost:3080';
 }
 
+/** Server-to-server API URL. Falls back to getApiBaseUrl() if API_SERVER_URL is not set. */
+export function getServerApiUrl(): string {
+  if (typeof process !== 'undefined' && process.env?.API_SERVER_URL) {
+    return process.env.API_SERVER_URL;
+  }
+  return getApiBaseUrl();
+}
+
 /**
  * Make an authenticated request to the LibreChat API.
  * Reads the JWT token from the admin session and sets the Authorization header.
@@ -23,7 +31,7 @@ export async function apiFetch(path: string, init?: RequestInit): Promise<Respon
     throw new Error('No admin session token available');
   }
 
-  const url = `${getApiBaseUrl()}${path}`;
+  const url = `${getServerApiUrl()}${path}`;
   return fetch(url, {
     ...init,
     headers: {


### PR DESCRIPTION
Adds API_SERVER_URL env var so server-to-server API calls can use a different URL than browser-facing OAuth redirects. If not set, everything behaves exactly as before.