### PR TITLE
🐛 fix: Copy tools/ Dir in Dockerfile for Local ESLint Plugin Dependency and Pin Bun to Latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Base ---
-FROM oven/bun:alpine AS base
+FROM oven/bun:1.3.11-alpine AS base
 WORKDIR /app
 
 # --- Install ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Base ---
-FROM oven/bun:1.3.3-alpine AS base
+FROM oven/bun:alpine AS base
 WORKDIR /app
 
 # --- Install ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 FROM base AS deps
 COPY package.json bun.lock .npmrc ./
 COPY patches/ patches/
+COPY tools/ tools/
 RUN bun install --frozen-lockfile
 
 # --- Build ---
@@ -19,6 +20,7 @@ RUN bun run build
 FROM base AS prod-deps
 COPY package.json bun.lock .npmrc ./
 COPY patches/ patches/
+COPY tools/ tools/
 RUN bun install --frozen-lockfile \
     && bun install --frozen-lockfile --production
 


### PR DESCRIPTION
package.json has a `file:./tools/eslint-plugin-click-ui` dependency. The Dockerfile wasn't copying `tools/` before `bun install`, so the install fails with "Failed to install 1 package".

Adds `COPY tools/ tools/` to both the deps and prod-deps stages and sets bun to latest, rather than pinning to specific version