### PR TITLE
🐳 feat: Add GHCR Docker Image Publish Workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,48 @@
+name: Docker Image Publish
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'server.ts'
+      - 'package.json'
+      - 'bun.lock'
+      - 'Dockerfile'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/librechat-admin-panel:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/librechat-admin-panel:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Adds a GitHub Actions workflow to build and publish the admin panel Docker image to GitHub Container Registry.

- Triggers on push to main (when src/Dockerfile/deps change) + manual dispatch
- Publishes to `ghcr.io/clickhouse/librechat-admin-panel`
- Tags with git SHA + `latest`
- Multi-platform: linux/amd64 + linux/arm64
- Uses GITHUB_TOKEN (no extra secrets needed)