### PR TITLE
🐛 fix: Lowercase GHCR Tag and Add Workflow Path Trigger

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,7 @@ on:
       - 'package.json'
       - 'bun.lock'
       - 'Dockerfile'
+      - '.github/workflows/docker-publish.yml'
 
 jobs:
   build:
@@ -43,6 +44,6 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/librechat-admin-panel:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/librechat-admin-panel:latest
+            ghcr.io/clickhouse/librechat-admin-panel:${{ github.sha }}
+            ghcr.io/clickhouse/librechat-admin-panel:latest
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Fixes two issues with the Docker publish workflow:

1. `github.repository_owner` returns `ClickHouse` (uppercase) but GHCR requires lowercase tags
2. The workflow file itself wasn't in the `paths` filter, so merging it didn't trigger a build