### PR TITLE
🐳 chore: Use Published GHCR Image in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   admin-panel:
-    build: .
+    image: ghcr.io/clickhouse/librechat-admin-panel:latest
     ports:
       - '${PORT:-3000}:${PORT:-3000}'
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Now that the GHCR package is public, switch `docker-compose.yml` from `build: .` to `image: ghcr.io/clickhouse/librechat-admin-panel:latest` so users can run the admin panel with `docker compose up` without building locally.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. `docker compose up` — should pull the image from GHCR and start on port 3000
2. Verify the admin panel is accessible at `http://localhost:3000`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings