### PR TITLE
🔭 feat(o11y): Add Prometheus Metrics Endpoint and HTTP Instrumentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 SESSION_SECRET=
 
 # ── Optional ─────────────────────────────────────────────────
+# Bearer token required to scrape the /metrics (Prometheus) endpoint.
+# The endpoint returns 401 if this is unset or the token does not match.
+# ADMIN_PANEL_METRICS_SECRET=
+
 # Browser-facing URL of the LibreChat API server (used for OAuth redirects).
 # Defaults to http://localhost:3080
 # VITE_API_BASE_URL=http://localhost:3080

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "js-yaml": "^4.1.1",
         "librechat-data-provider": "^0.8.407",
         "lucide-react": "^0.545.0",
+        "prom-client": "^15.1.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.4",
@@ -281,6 +282,8 @@
     "@oozcitak/url": ["@oozcitak/url@3.0.0", "", { "dependencies": { "@oozcitak/infra": "2.0.2", "@oozcitak/util": "10.0.0" } }, "sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ=="],
 
     "@oozcitak/util": ["@oozcitak/util@10.0.0", "", {}, "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
 
@@ -741,6 +744,8 @@
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -1336,6 +1341,8 @@
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
+    "prom-client": ["prom-client@15.1.3", "", { "dependencies": { "@opentelemetry/api": "^1.4.0", "tdigest": "^0.1.1" } }, "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -1489,6 +1496,8 @@
     "tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "tdigest": ["tdigest@0.1.2", "", { "dependencies": { "bintrees": "1.0.2" } }, "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA=="],
 
     "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "js-yaml": "^4.1.1",
     "librechat-data-provider": "^0.8.407",
     "lucide-react": "^0.545.0",
+    "prom-client": "^15.1.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.4",

--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,6 @@
 import { Glob } from 'bun';
 import { join } from 'node:path';
+import { metricsResponse, httpRequestsTotal, httpRequestDurationSeconds } from './src/server/metrics';
 
 const CLIENT_DIR = join(import.meta.dir, 'dist', 'client');
 const SERVER_ENTRY = new URL('./dist/server/server.js', import.meta.url);
@@ -50,8 +51,14 @@ Bun.serve({
   port: Number(process.env.PORT ?? 3000),
   routes: {
     ...(await buildStaticRoutes()),
+    '/metrics': () => metricsResponse(),
     '/*': async (req) => {
+      const url = new URL(req.url);
+      const end = httpRequestDurationSeconds.startTimer({ method: req.method, path: url.pathname });
       const res = await handler.fetch(req);
+      const statusCode = String(res.status);
+      httpRequestsTotal.inc({ method: req.method, path: url.pathname, status_code: statusCode });
+      end({ status_code: statusCode });
       const patched = new Response(res.body, res);
       for (const [k, v] of Object.entries(NO_CACHE)) {
         patched.headers.set(k, v);

--- a/server.ts
+++ b/server.ts
@@ -36,6 +36,10 @@ type Handler = { default: { fetch: (req: Request) => Promise<Response> } };
 
 const { default: handler } = (await import(SERVER_ENTRY.href)) as Handler;
 
+if (!process.env.ADMIN_PANEL_METRICS_SECRET) {
+  console.warn('[metrics] ADMIN_PANEL_METRICS_SECRET is not set — /metrics will return 401 for all requests');
+}
+
 async function buildStaticRoutes(): Promise<Record<string, () => Response>> {
   const routes: Record<string, () => Response> = {};
   for await (const path of new Glob('**/*').scan(CLIENT_DIR)) {
@@ -51,7 +55,7 @@ Bun.serve({
   port: Number(process.env.PORT ?? 3000),
   routes: {
     ...(await buildStaticRoutes()),
-    '/metrics': () => metricsResponse(),
+    '/metrics': (req) => metricsResponse(req),
     '/*': async (req) => {
       const url = new URL(req.url);
       const end = httpRequestDurationSeconds.startTimer({ method: req.method, path: url.pathname });

--- a/src/server/metrics.ts
+++ b/src/server/metrics.ts
@@ -1,0 +1,23 @@
+import client, { register } from 'prom-client';
+
+client.collectDefaultMetrics();
+
+export const httpRequestsTotal = new client.Counter({
+  name: 'admin_http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'path', 'status_code'] as const,
+});
+
+export const httpRequestDurationSeconds = new client.Histogram({
+  name: 'admin_http_request_duration_seconds',
+  help: 'Duration of HTTP requests in seconds',
+  labelNames: ['method', 'path', 'status_code'] as const,
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+export async function metricsResponse(): Promise<Response> {
+  const data = await register.metrics();
+  return new Response(data, {
+    headers: { 'Content-Type': register.contentType },
+  });
+}

--- a/src/server/metrics.ts
+++ b/src/server/metrics.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'crypto';
 import client, { register } from 'prom-client';
 
 client.collectDefaultMetrics();
@@ -15,9 +16,29 @@ export const httpRequestDurationSeconds = new client.Histogram({
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 });
 
-export async function metricsResponse(): Promise<Response> {
-  const data = await register.metrics();
-  return new Response(data, {
-    headers: { 'Content-Type': register.contentType },
-  });
+export async function metricsResponse(req: Request): Promise<Response> {
+  const secret = process.env.ADMIN_PANEL_METRICS_SECRET;
+  const auth = req.headers.get('authorization');
+  if (!secret || !auth) return new Response(null, { status: 401 });
+
+  const token = auth.replace(/^bearer\s+/i, '');
+  const encode = (s: string) => new TextEncoder().encode(s);
+  const expected = encode(secret);
+  const actual = encode(token);
+  const maxLen = Math.max(expected.byteLength, actual.byteLength);
+  const paddedExpected = new Uint8Array(maxLen);
+  const paddedActual = new Uint8Array(maxLen);
+  paddedExpected.set(expected);
+  paddedActual.set(actual);
+  const lengthMatch = expected.byteLength === actual.byteLength;
+  if (!timingSafeEqual(paddedExpected, paddedActual) || !lengthMatch) {
+    return new Response(null, { status: 401 });
+  }
+
+  try {
+    const data = await register.metrics();
+    return new Response(data, { headers: { 'Content-Type': register.contentType } });
+  } catch {
+    return new Response(null, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Summary

Adds prometheus metrics endpoint

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Start - visit `/metrics`

1. curl http://localhost:3000/metrics returned default process metrics (CPU, memory, event loop lag, etc.)
2. Made requests to / and /login, then re-curled /metrics -- confirmed both `admin_http_requests_total` and `admin_http_request_duration_seconds` appeared with correct labels:

```prom
admin_http_requests_total{method="GET",path="/",status_code="200"} 1
admin_http_requests_total{method="GET",path="/login",status_code="307"} 1
admin_http_request_duration_seconds_sum{method="GET",path="/",status_code="200"} 0.162622
admin_http_request_duration_seconds_sum{method="GET",path="/login",status_code="307"} 0.000762375
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.