### PR TITLE
🛠 chore: Copy `src/server` to Runtime Image for Metrics Module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV NODE_ENV=production
 
 COPY --from=prod-deps /app/node_modules node_modules
 COPY --from=build /app/dist dist
+COPY --from=build /app/src/server src/server
 COPY server.ts package.json ./
 
 RUN chown -R bun:bun /app


### PR DESCRIPTION
## Summary
Adds `COPY --from=build /app/src/server src/server` to the Dockerfile runtime stage.

`server.ts` imports `./src/server/metrics` at runtime (Bun runs it directly, not compiled into `dist/`). Without the source file in the image, the container crash-loops with:

```
error: Cannot find module './src/server/metrics' from '/app/server.ts'
```

## Test plan
- [ ] `docker build` succeeds
- [ ] Container starts without module resolution errors