### PR TITLE
🐛 fix: Preserve typed values when adding entries to new sections

### DIFF
--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -35,6 +35,7 @@ import { StickyActionBar } from '@/components/shared';
 import { ConfigTabContent } from './ConfigTabContent';
 import { ImportYamlDialog } from './ImportYamlDialog';
 import { ContentToolbar } from './ContentToolbar';
+import { mergeIndexedArrayEdits } from './utils';
 import { SystemCapabilities } from '@/constants';
 import { ConfigTabBar } from './ConfigTabBar';
 import { InfoBanner } from './InfoBanner';
@@ -276,25 +277,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     if (!baseActiveConfigValues) return baseActiveConfigValues;
     const indexedEdits = Object.entries(editedValues).filter(([k]) => /\.\d+$/.test(k));
     if (indexedEdits.length === 0) return baseActiveConfigValues;
-    const merged = { ...baseActiveConfigValues };
-    for (const [path, value] of indexedEdits) {
-      const segments = path.split('.');
-      const index = Number(segments.pop()!);
-      const arrayPath = segments;
-      let parent: Record<string, t.ConfigValue> = merged;
-      for (let i = 0; i < arrayPath.length - 1; i++) {
-        const seg = arrayPath[i];
-        if (parent[seg] && typeof parent[seg] === 'object' && !Array.isArray(parent[seg])) {
-          parent[seg] = { ...(parent[seg] as Record<string, t.ConfigValue>) };
-          parent = parent[seg] as Record<string, t.ConfigValue>;
-        } else break;
-      }
-      const lastSeg = arrayPath[arrayPath.length - 1];
-      const arr = Array.isArray(parent[lastSeg]) ? [...(parent[lastSeg] as t.ConfigValue[])] : [];
-      arr[index] = value;
-      parent[lastSeg] = arr;
-    }
-    return merged;
+    return mergeIndexedArrayEdits(baseActiveConfigValues, indexedEdits);
   }, [baseActiveConfigValues, editedValues]);
 
   const scopeConfiguredPaths = useMemo(() => {

--- a/src/components/configuration/utils.test.ts
+++ b/src/components/configuration/utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getControlType, getEnumOptions, getArrayItemType, splitUnionTypes } from './utils';
+import {
+  getControlType,
+  getEnumOptions,
+  getArrayItemType,
+  splitUnionTypes,
+  mergeIndexedArrayEdits,
+} from './utils';
 import { createField } from '@/test/fixtures';
 
 describe('getControlType', () => {
@@ -234,5 +240,95 @@ describe('getEnumOptions — union(literal(...)) parsing', () => {
   it('returns empty array for non-enum/non-literal-union input', () => {
     expect(getEnumOptions('string')).toEqual([]);
     expect(getEnumOptions('union(string | number)')).toEqual([]);
+  });
+});
+
+describe('mergeIndexedArrayEdits', () => {
+  it('creates the array under a parent path absent from the baseline', () => {
+    /**
+     * Regression: the merge previously bailed out and wrote the array at the
+     * wrong nesting level when its parent (e.g. modelSpecs) wasn't in
+     * librechat.yaml, causing typed list entries to disappear from view.
+     */
+    const merged = mergeIndexedArrayEdits({}, [
+      ['modelSpecs.list.0', { name: 'test', label: 'Test' }],
+    ]);
+    expect(merged).toEqual({
+      modelSpecs: { list: [{ name: 'test', label: 'Test' }] },
+    });
+  });
+
+  it('preserves baseline siblings when introducing a new section', () => {
+    const merged = mergeIndexedArrayEdits({ interface: { parameters: true } }, [
+      ['modelSpecs.list.0', { name: 'a' }],
+    ]);
+    expect(merged).toEqual({
+      interface: { parameters: true },
+      modelSpecs: { list: [{ name: 'a' }] },
+    });
+  });
+
+  it('merges into an existing parent without clobbering its keys', () => {
+    const merged = mergeIndexedArrayEdits(
+      { modelSpecs: { enforce: true, prioritize: false } },
+      [['modelSpecs.list.0', { name: 'a' }]],
+    );
+    expect(merged.modelSpecs).toEqual({
+      enforce: true,
+      prioritize: false,
+      list: [{ name: 'a' }],
+    });
+  });
+
+  it('places multiple indexed edits at their correct positions', () => {
+    const merged = mergeIndexedArrayEdits({}, [
+      ['modelSpecs.list.0', { name: 'a' }],
+      ['modelSpecs.list.2', { name: 'c' }],
+    ]);
+    const list = (merged.modelSpecs as { list: Array<{ name: string } | undefined> }).list;
+    expect(list[0]).toEqual({ name: 'a' });
+    expect(list[1]).toBeUndefined();
+    expect(list[2]).toEqual({ name: 'c' });
+  });
+
+  it('returns the baseline unchanged when there are no indexed edits', () => {
+    const baseline = { interface: { parameters: true } };
+    expect(mergeIndexedArrayEdits(baseline, [])).toEqual(baseline);
+  });
+
+  it('does not mutate the baseline object', () => {
+    const baseline: Record<string, unknown> = { modelSpecs: { enforce: true } };
+    const before = JSON.parse(JSON.stringify(baseline));
+    mergeIndexedArrayEdits(baseline as Record<string, never>, [
+      ['modelSpecs.list.0', { name: 'a' }],
+    ]);
+    expect(baseline).toEqual(before);
+  });
+
+  it('skips an edit when an intermediate path is a primitive', () => {
+    /**
+     * Defensive: refuse to overwrite a primitive at an intermediate path
+     * because doing so would silently destroy unrelated baseline data.
+     */
+    const merged = mergeIndexedArrayEdits({ modelSpecs: 'not-an-object' }, [
+      ['modelSpecs.list.0', { name: 'a' }],
+    ]);
+    expect(merged).toEqual({ modelSpecs: 'not-an-object' });
+  });
+
+  it('skips an edit when an intermediate path is an array', () => {
+    const merged = mergeIndexedArrayEdits({ modelSpecs: [1, 2, 3] }, [
+      ['modelSpecs.list.0', { name: 'a' }],
+    ]);
+    expect(merged).toEqual({ modelSpecs: [1, 2, 3] });
+  });
+
+  it('walks deep parent chains, creating each missing level', () => {
+    const merged = mergeIndexedArrayEdits({}, [
+      ['endpoints.custom.deep.list.0', { name: 'x' }],
+    ]);
+    expect(merged).toEqual({
+      endpoints: { custom: { deep: { list: [{ name: 'x' }] } } },
+    });
   });
 });

--- a/src/components/configuration/utils.ts
+++ b/src/components/configuration/utils.ts
@@ -222,3 +222,48 @@ export function hasDescendant(path: string, paths?: Set<string>): boolean {
   }
   return false;
 }
+
+/**
+ * Merge indexed-array edits (entries whose flat path ends in `.<digit>`) into
+ * a config tree. Each indexed edit's value replaces the array element at that
+ * index; the array's parent path is auto-created if absent so newly-introduced
+ * sections (e.g. `modelSpecs` not present in `librechat.yaml`) merge in at the
+ * correct nesting level rather than getting written to the wrong parent.
+ *
+ * Skips an edit when an intermediate path holds a primitive or array value,
+ * since overwriting those with a fresh object would silently destroy live
+ * baseline data. Caller is responsible for filtering `editedValues` down to
+ * indexed entries before passing.
+ */
+export function mergeIndexedArrayEdits(
+  baseline: Record<string, t.ConfigValue>,
+  indexedEdits: Array<[string, t.ConfigValue]>,
+): Record<string, t.ConfigValue> {
+  const merged = { ...baseline };
+  for (const [path, value] of indexedEdits) {
+    const segments = path.split('.');
+    const index = Number(segments.pop()!);
+    const arrayPath = segments;
+    let parent: Record<string, t.ConfigValue> = merged;
+    let bailed = false;
+    for (let i = 0; i < arrayPath.length - 1; i++) {
+      const seg = arrayPath[i];
+      const existing = parent[seg];
+      if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+        parent[seg] = { ...(existing as Record<string, t.ConfigValue>) };
+      } else if (existing == null) {
+        parent[seg] = {};
+      } else {
+        bailed = true;
+        break;
+      }
+      parent = parent[seg] as Record<string, t.ConfigValue>;
+    }
+    if (bailed) continue;
+    const lastSeg = arrayPath[arrayPath.length - 1];
+    const arr = Array.isArray(parent[lastSeg]) ? [...(parent[lastSeg] as t.ConfigValue[])] : [];
+    arr[index] = value;
+    parent[lastSeg] = arr;
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary

When the user adds an entry to an array field whose parent section isn't present in `librechat.yaml` (e.g. `modelSpecs.list` when `modelSpecs` isn't configured), typed values silently disappear on blur. The entry appears, the user types into a field, clicks out, and the entry collapses with no values; saves persist `list: [{}]` instead of the typed values.

The cause is in `ConfigPage.tsx`'s `activeConfigValues` merge. When the form combines indexed-array edits (`modelSpecs.list.0 = { name: "test" }`) with the baseline, it walks segments of the parent path and bails out on missing intermediates. With `modelSpecs` absent from the YAML, `merged.modelSpecs` was never created, so the loop broke early and the indexed entry got written as `merged.list = [{ name: "test" }]` at the **root** instead of `merged.modelSpecs.list`. The form then read `activeConfigValues.modelSpecs?.list` (still undefined), got nothing, and the entry vanished from view.

**Fix:**

* Auto-creates missing intermediate object nodes during the merge so newly-introduced sections (e.g. `modelSpecs` not present in `librechat.yaml`) merge in at the correct nesting level.
* Defensively bails out only when an intermediate already holds a primitive or array — overwriting those would silently destroy live baseline data.
* Extracts the merge into a pure `mergeIndexedArrayEdits` helper in `utils.ts` so the behavior is unit-testable.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

9 unit tests in `utils.test.ts` covering:

* Regression case: typed entry persists when parent section is absent from baseline (`modelSpecs.list.0` → `modelSpecs.list = [...]`).
* Sibling preservation: introducing a new section doesn't clobber unrelated baseline keys.
* Existing parent: merging into a section that already has overrides preserves its other keys.
* Multi-index: multiple indexed edits at non-contiguous positions place correctly.
* Empty / no-op: returns the baseline unchanged when no indexed edits are present.
* Immutability: does not mutate the baseline object.
* Defensive bail: skips the edit when an intermediate path holds a primitive (e.g. `modelSpecs: 'not-an-object'`).
* Defensive bail: skips the edit when an intermediate path holds an array.
* Deep chain: walks `endpoints.custom.deep.list.0` and creates each missing level.

### Test Configuration

* Verified manually: `Configuration → Model specs → Add entry → fill name/label/preset.endpoint → blur` keeps the entry visible with the typed values populated.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes