### PR TITLE
🐛 fix: Stop guessing URL fields from key names in config form

### DIFF
--- a/src/components/configuration/FieldRenderer.tsx
+++ b/src/components/configuration/FieldRenderer.tsx
@@ -360,8 +360,6 @@ export function SingleFieldRenderer({
   if (controlType === 'text') {
     const stringValue = typeof currentValue === 'string' ? currentValue : '';
     const isMultiline = stringValue.includes('\n') || field.key.toLowerCase().includes('content');
-    const isUrl =
-      field.key.toLowerCase().includes('url') || field.key.toLowerCase().includes('endpoint');
 
     if (isMultiline) {
       const control = (
@@ -392,8 +390,7 @@ export function SingleFieldRenderer({
         id={fieldId}
         value={stringValue}
         onChange={(v) => onChange(path, v)}
-        placeholder={isUrl ? localize('com_ui_enter_url') : undefined}
-        type={isUrl ? 'url' : 'text'}
+        type="text"
         disabled={disabled}
       />
     );


### PR DESCRIPTION
## Summary

Capital letters cannot be typed into the modelSpec preset `endpoint` field, only lowercase works, Shift-letter is swallowed. Makes valid endpoint values like `openAI`, `azureOpenAI`, `azureAssistants` impossible to enter from the admin panel.

`FieldRenderer` was inferring URL-ness from a substring match on the field key (`url`, `endpoint`). The `'endpoint'` substring matched `modelSpecs.list[].preset.endpoint` — a categorical enum (`openAI`, `anthropic`, etc.), not a URL. The form rendered it as `<input type="url">`, and browser autofill on URL-typed inputs swallowed shifted keystrokes.

**Fix:**

* Drop the keyword heuristic entirely. LibreChat's `configSchema` declares **zero** `.url()` validations today, so no field in the form should be rendered as `type="url"`. If the schema ever tags a field with `.url()`, detection can be added at the schema-extraction layer (`extractSchemaTree` in `src/server/config.ts`) at that point.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

* Manually verified: typing `openAI` in `Configuration → Model specs → list[0] → Preset → Endpoint` now produces `openAI` (capital A registers).
* Existing URL-keyed fields (`baseURL`, `iconURL`, `searxngInstanceUrl`, etc.) lose their `placeholder="https://..."` and `type="url"` rendering — they're plain text inputs now. Cosmetic only; no validation change because the schema didn't enforce URL-ness in the first place.
* `bun run lint` clean. `bunx tsc --noEmit` clean. 528/528 tests pass.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes