### PR TITLE
🐛 fix: Move `useEffect` before conditional return in `AppLayout`

### DIFF
--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -50,15 +50,6 @@ function AppLayout() {
   });
   const pathname = router.state.location.pathname;
 
-  if (!isLoading && !isError && !hasCapability(SystemCapabilities.ACCESS_ADMIN)) {
-    return <AccessDenied />;
-  }
-
-  const matchedKey = Object.keys(ROUTE_TITLE_KEYS).find((route) =>
-    route === '/' ? pathname === '/' : pathname.startsWith(route),
-  );
-  const title = matchedKey ? localize(ROUTE_TITLE_KEYS[matchedKey]) : undefined;
-
   const toggleSidebar = () =>
     setSidebarCollapsed((prev) => {
       const next = !prev;
@@ -76,6 +67,15 @@ function AppLayout() {
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
+
+  if (!isLoading && !isError && !hasCapability(SystemCapabilities.ACCESS_ADMIN)) {
+    return <AccessDenied />;
+  }
+
+  const matchedKey = Object.keys(ROUTE_TITLE_KEYS).find((route) =>
+    route === '/' ? pathname === '/' : pathname.startsWith(route),
+  );
+  const title = matchedKey ? localize(ROUTE_TITLE_KEYS[matchedKey]) : undefined;
 
   return (
     <div className="flex h-screen overflow-hidden">


### PR DESCRIPTION
The `useEffect` hook was called after a conditional early return, violating React's Rules of Hooks. Moved `toggleSidebar` and its `useEffect` above the `AccessDenied` guard so hooks are always called in the same order.

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
