### PR TITLE
fix: bound admin panel metrics labels

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,11 @@
 import { Glob } from 'bun';
 import { join } from 'node:path';
-import { metricsResponse, httpRequestsTotal, httpRequestDurationSeconds } from './src/server/metrics';
+import {
+  metricsResponse,
+  httpRequestsTotal,
+  httpRequestDurationSeconds,
+  normalizeMetricsPath,
+} from './src/server/metrics';
 
 const CLIENT_DIR = join(import.meta.dir, 'dist', 'client');
 const SERVER_ENTRY = new URL('./dist/server/server.js', import.meta.url);
@@ -14,7 +19,10 @@ const maxAge = Number.isNaN(rawMaxAge) ? ONE_DAY * 2 : rawMaxAge;
 const sMaxAge = Number.isNaN(rawSMaxAge) ? ONE_DAY : rawSMaxAge;
 
 const NO_CACHE: Record<string, string> = {
-  'Cache-Control': env.ADMIN_PANEL_INDEX_CACHE_CONTROL ?? env.INDEX_CACHE_CONTROL ?? 'no-cache, no-store, must-revalidate',
+  'Cache-Control':
+    env.ADMIN_PANEL_INDEX_CACHE_CONTROL ??
+    env.INDEX_CACHE_CONTROL ??
+    'no-cache, no-store, must-revalidate',
   Pragma: env.ADMIN_PANEL_INDEX_PRAGMA ?? env.INDEX_PRAGMA ?? 'no-cache',
   Expires: env.ADMIN_PANEL_INDEX_EXPIRES ?? env.INDEX_EXPIRES ?? '0',
 };
@@ -36,13 +44,32 @@ type Handler = { default: { fetch: (req: Request) => Promise<Response> } };
 
 const { default: handler } = (await import(SERVER_ENTRY.href)) as Handler;
 
-async function buildStaticRoutes(): Promise<Record<string, () => Response>> {
-  const routes: Record<string, () => Response> = {};
+async function withHttpMetrics(
+  req: Request,
+  pathname: string,
+  getResponse: () => Response | Promise<Response>,
+): Promise<Response> {
+  const path = normalizeMetricsPath(pathname);
+  const end = httpRequestDurationSeconds.startTimer({ method: req.method, path });
+  const res = await getResponse();
+  const statusCode = String(res.status);
+  httpRequestsTotal.inc({ method: req.method, path, status_code: statusCode });
+  end({ status_code: statusCode });
+  return res;
+}
+
+async function buildStaticRoutes(): Promise<Record<string, (req: Request) => Promise<Response>>> {
+  const routes: Record<string, (req: Request) => Promise<Response>> = {};
   for await (const path of new Glob('**/*').scan(CLIENT_DIR)) {
     const file = Bun.file(`${CLIENT_DIR}/${path}`);
     const cache = getCacheHeaders(path);
-    routes[`/${path}`] = () =>
-      new Response(file, { headers: { 'Content-Type': file.type, ...cache } });
+    const routePath = `/${path}`;
+    routes[routePath] = (req) =>
+      withHttpMetrics(
+        req,
+        routePath,
+        () => new Response(file, { headers: { 'Content-Type': file.type, ...cache } }),
+      );
   }
   return routes;
 }
@@ -54,11 +81,7 @@ const server = Bun.serve({
     '/metrics': (req) => metricsResponse(req),
     '/*': async (req) => {
       const url = new URL(req.url);
-      const end = httpRequestDurationSeconds.startTimer({ method: req.method, path: url.pathname });
-      const res = await handler.fetch(req);
-      const statusCode = String(res.status);
-      httpRequestsTotal.inc({ method: req.method, path: url.pathname, status_code: statusCode });
-      end({ status_code: statusCode });
+      const res = await withHttpMetrics(req, url.pathname, () => handler.fetch(req));
       const patched = new Response(res.body, res);
       for (const [k, v] of Object.entries(NO_CACHE)) {
         patched.headers.set(k, v);
@@ -71,5 +94,7 @@ const server = Bun.serve({
 console.log(`Admin panel listening on http://localhost:${server.port}`);
 
 if (!process.env.ADMIN_PANEL_METRICS_SECRET) {
-  console.warn('[metrics] ADMIN_PANEL_METRICS_SECRET is not set — /metrics will return 401 for all requests');
+  console.warn(
+    '[metrics] ADMIN_PANEL_METRICS_SECRET is not set — /metrics will return 401 for all requests',
+  );
 }

--- a/src/server/metrics.test.ts
+++ b/src/server/metrics.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMetricsPath } from './metrics';
+
+describe('normalizeMetricsPath', () => {
+  it.each([
+    ['/', '/'],
+    ['/login', '/login'],
+    ['/configuration/', '/configuration'],
+    ['/auth/openid/callback', '/auth/openid/callback'],
+  ])('keeps known app route %s bounded as %s', (input, expected) => {
+    expect(normalizeMetricsPath(input)).toBe(expected);
+  });
+
+  it.each([
+    ['/assets/index-abc123.js'],
+    ['/favicon.ico'],
+    ['/manifest.json'],
+    ['/clickhouse-dark.svg'],
+  ])('buckets static asset %s', (input) => {
+    expect(normalizeMetricsPath(input)).toBe('static_asset');
+  });
+
+  it.each([
+    ['/_server'],
+    ['/_server/getUsersFn'],
+    ['/_serverFn/getUsersFn'],
+    ['/api/_server/getUsersFn'],
+  ])('buckets server function path %s', (input) => {
+    expect(normalizeMetricsPath(input)).toBe('server_function');
+  });
+
+  it.each([['/wp-login.php'], ['/users/123'], ['not-a-path']])(
+    'buckets unknown path %s',
+    (input) => {
+      expect(normalizeMetricsPath(input)).toBe('unknown');
+    },
+  );
+});

--- a/src/server/metrics.ts
+++ b/src/server/metrics.ts
@@ -3,6 +3,53 @@ import client, { register } from 'prom-client';
 
 client.collectDefaultMetrics();
 
+const KNOWN_APP_ROUTES = new Map<string, string>([
+  ['/', '/'],
+  ['/login', '/login'],
+  ['/access', '/access'],
+  ['/configuration', '/configuration'],
+  ['/grants', '/grants'],
+  ['/help', '/help'],
+  ['/users', '/users'],
+  ['/auth/openid/callback', '/auth/openid/callback'],
+]);
+
+const STATIC_ASSET_RE =
+  /\.(?:avif|css|gif|ico|jpe?g|js|json|map|png|svg|txt|webmanifest|webp|woff2?)$/i;
+
+const SERVER_FUNCTION_PREFIXES = [
+  '/_server',
+  '/_serverFn',
+  '/__server',
+  '/_tanstack',
+  '/api/_server',
+];
+
+function canonicalPath(pathname: string): string {
+  if (!pathname.startsWith('/')) return '/unknown';
+  if (pathname === '/') return pathname;
+  return pathname.replace(/\/+$/, '');
+}
+
+export function normalizeMetricsPath(pathname: string): string {
+  const path = canonicalPath(pathname);
+
+  const appRoute = KNOWN_APP_ROUTES.get(path);
+  if (appRoute) return appRoute;
+
+  if (path === '/metrics') return '/metrics';
+
+  if (path.startsWith('/assets/') || STATIC_ASSET_RE.test(path)) {
+    return 'static_asset';
+  }
+
+  if (SERVER_FUNCTION_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))) {
+    return 'server_function';
+  }
+
+  return 'unknown';
+}
+
 export const httpRequestsTotal = new client.Counter({
   name: 'admin_http_requests_total',
   help: 'Total number of HTTP requests',


### PR DESCRIPTION
## Summary

I bounded admin panel HTTP metrics labels so Prometheus cannot retain one series per arbitrary request path, reducing the risk of request-driven memory growth after the OOMKilled incident.

- Added `normalizeMetricsPath` to collapse app routes, static assets, TanStack server functions, and unknown paths into a fixed set of labels.
- Wrapped both static-route and app-route responses with shared HTTP metrics recording so request counters and histograms use the normalized path label.
- Added coverage for known routes, static assets, server-function paths, and arbitrary unknown paths.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `bun run test src/server/metrics.test.ts`.
- Ran `bun run lint`.
- Ran `SESSION_SECRET=dev-only-session-secret-minimum-32-chars! bun run test`.
- Ran `bun run build`.
- Smoke-tested the built Bun server and verified `/metrics` emitted bounded labels for `static_asset`, `server_function`, and `unknown`.

### **Test Configuration**:

- Bun 1.3.13
- Vitest 3.2.4
- Vite 8.0.3

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes