### PR TITLE
fix: use durable mcp tombstones for scoped deletes

### DIFF
--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -520,8 +520,17 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     const mcpEdits: Array<[string, t.ConfigValue]> = touched
       .filter((p) => p.startsWith('mcpServers.'))
       .map((p) => [p, editedValues[p]] as [string, t.ConfigValue]);
+    /** In scope mode, a leaf reset (undefined write) only removes the scope override and reveals the inherited base value, so feed configValues as the resetFallback. In base mode there is nothing to inherit from. */
+    const mcpResetFallback = (() => {
+      if (!isEditingScope) return undefined;
+      const v = configValues?.mcpServers;
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        return v as Record<string, t.ConfigValue>;
+      }
+      return undefined;
+    })();
     if (mcpEdits.length > 0) {
-      const mcpErrors = validateMcpCrossField(mcpBaseline, mcpEdits);
+      const mcpErrors = validateMcpCrossField(mcpBaseline, mcpEdits, mcpResetFallback);
       if (mcpErrors.length > 0) {
         const { entryKey, missingField } = mcpErrors[0];
         const message = localize('com_config_mcp_invalid_after_edit', {
@@ -606,6 +615,8 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     invalidateAndResetScope,
     saving,
     baseActiveConfigValues,
+    configValues,
+    isEditingScope,
     localize,
   ]);
 

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -509,9 +509,9 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     const touched = [...touchedPaths].filter((p) => p in editedValues);
     if (touched.length === 0) return;
 
-    /** Per-leaf saves can land an MCP entry in a transport state whose required siblings are missing (e.g. type=stdio with no command/args). Server-side per-field validation only sees one path at a time, so do the cross-field check here against the merged effective entry before any PATCH fires. */
+    /** Per-leaf saves can land an MCP entry in a transport state whose required siblings are missing (e.g. type=stdio with no command/args). Server-side per-field validation only sees one path at a time, so do the cross-field check here against the merged effective entry before any PATCH fires. Use baseActiveConfigValues so scope-mode edits validate against the scope-resolved baseline (where prior scope overrides supply some required fields) instead of the base config alone. */
     const mcpBaseline = (() => {
-      const v = configValues?.mcpServers;
+      const v = baseActiveConfigValues?.mcpServers;
       if (v && typeof v === 'object' && !Array.isArray(v)) {
         return v as Record<string, t.ConfigValue>;
       }
@@ -605,7 +605,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     invalidateAndResetBase,
     invalidateAndResetScope,
     saving,
-    configValues,
+    baseActiveConfigValues,
     localize,
   ]);
 

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -365,6 +365,24 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     return set;
   }, [scopeBaseline]);
 
+  /** Container paths walked directly off the structured config, so an orphaned `{}` entry whose flatten dropped (or never produced) any leaf is still recognized as a real subtree-delete target. */
+  const baselineContainerPaths = useMemo(() => {
+    const set = new Set<string>();
+    const walk = (obj: unknown, prefix: string): void => {
+      if (obj == null || typeof obj !== 'object' || Array.isArray(obj)) return;
+      for (const k of Object.keys(obj as Record<string, unknown>)) {
+        const path = prefix ? `${prefix}.${k}` : k;
+        const v = (obj as Record<string, unknown>)[k];
+        if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+          set.add(path);
+          walk(v, path);
+        }
+      }
+    };
+    walk(baseActiveConfigValues, '');
+    return set;
+  }, [baseActiveConfigValues]);
+
   const handleFieldChange = useCallback(
     (path: string, value: t.ConfigValue) => {
       setTouchedPaths((prev) => {
@@ -380,8 +398,10 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
           (typeof value === 'object' &&
             typeof baseline === 'object' &&
             JSON.stringify(value) === JSON.stringify(baseline));
-        /** A container-path undefined write must survive; baseline only stores leaves, so it would otherwise match `undefined === undefined` and get pruned. */
-        const isContainerDelete = value === undefined && baselineIntermediates.has(path);
+        /** A container-path undefined write must survive; baseline only stores leaves, so it would otherwise match `undefined === undefined` and get pruned. baselineContainerPaths catches the orphaned empty-object case where leaf-derived intermediates miss the entry. */
+        const isContainerDelete =
+          value === undefined &&
+          (baselineIntermediates.has(path) || baselineContainerPaths.has(path));
         if (match && !isContainerDelete) {
           const next = { ...prev };
           delete next[path];
@@ -405,7 +425,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
         return next;
       });
     },
-    [scopeBaseline, baselineIntermediates],
+    [scopeBaseline, baselineIntermediates, baselineContainerPaths],
   );
 
   const isDirty = Object.keys(editedValues).length > 0;

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -7,6 +7,7 @@ import { queryOptions, useQuery, useQueryClient, useMutation } from '@tanstack/r
 import type * as t from '@/types';
 import {
   removeFieldProfileValueFn,
+  tombstoneFieldProfileValueFn,
   bulkSaveProfileValuesFn,
   getBatchFieldProfilesFn,
   availableScopesOptions,
@@ -36,7 +37,7 @@ import { ConfigTabContent } from './ConfigTabContent';
 import { ImportYamlDialog } from './ImportYamlDialog';
 import { ContentToolbar } from './ContentToolbar';
 import { validateMcpCrossField } from './sections/McpServersRenderer';
-import { mergeIndexedArrayEdits } from './utils';
+import { mergeIndexedArrayEdits, partitionScopeResetPaths } from './utils';
 import { SystemCapabilities } from '@/constants';
 import { ConfigTabBar } from './ConfigTabBar';
 import { InfoBanner } from './InfoBanner';
@@ -565,19 +566,34 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     try {
       /** Resets must land before saves so a delete-then-recreate at the same path (e.g. MCP entry replaced with different fields) wipes stale fields first and the new leaf PATCHes don't race against the DELETE. */
       if (resets.length > 0) {
-        const resetPromises = resets.map((fieldPath) => {
-          if (isEditingScope) {
-            return removeFieldProfileValueFn({
-              data: {
-                fieldPath,
-                principalType: editingScope!.principalType,
-                principalId: editingScope!.principalId,
-              },
-            });
-          }
-          return resetBaseConfigFieldFn({ data: { fieldPath } });
-        });
-        await Promise.all(resetPromises);
+        const resetPromises = isEditingScope
+          ? (() => {
+              const { resetPaths, tombstonePaths } = partitionScopeResetPaths(resets);
+              return [
+                ...resetPaths.map((fieldPath) =>
+                  removeFieldProfileValueFn({
+                    data: {
+                      fieldPath,
+                      principalType: editingScope!.principalType,
+                      principalId: editingScope!.principalId,
+                    },
+                  }),
+                ),
+                ...tombstonePaths.map((fieldPath) =>
+                  tombstoneFieldProfileValueFn({
+                    data: {
+                      fieldPath,
+                      principalType: editingScope!.principalType,
+                      principalId: editingScope!.principalId,
+                    },
+                  }),
+                ),
+              ];
+            })()
+          : resets.map((fieldPath) => resetBaseConfigFieldFn({ data: { fieldPath } }));
+        if (resetPromises.length > 0) {
+          await Promise.all(resetPromises);
+        }
       }
 
       if (saves.length > 0) {
@@ -608,16 +624,16 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
   }, [
     touchedPaths,
     editedValues,
-    isEditingScope,
-    editingScope,
-    showToast,
-    invalidateAndResetBase,
-    invalidateAndResetScope,
     saving,
+    isEditingScope,
     baseActiveConfigValues,
     configValues,
     baseConfigData,
     localize,
+    showToast,
+    editingScope,
+    invalidateAndResetScope,
+    invalidateAndResetBase,
   ]);
 
   const serializedEditedValues = useMemo(() => {
@@ -926,6 +942,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
               sectionPermissions={sectionPermissions}
               schemaDefaults={schemaDefaults}
               showConfiguredOnly={showConfiguredOnly}
+              isEditingScope={isEditingScope}
               baseRecordKeys={baseRecordKeys}
               onValidationError={(message) => showToast({ type: 'error', message }, 5000)}
             />

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -405,6 +405,13 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
         if (match && !isContainerDelete) {
           const next = { ...prev };
           delete next[path];
+          /** Drop any orphaned ancestor `undefined` writes; a leaf returning to baseline means the user is re-asserting that subtree, so a stale "delete this whole entry" left over from a prior remove (e.g. delete-then-recreate-at-baseline) must not survive to hide the resurrected entry. */
+          for (const existing of Object.keys(next)) {
+            if (existing === path) continue;
+            if (path.startsWith(`${existing}.`) && next[existing] === undefined) {
+              delete next[existing];
+            }
+          }
           return next;
         }
         const next = { ...prev, [path]: value };

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -521,12 +521,11 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     const mcpEdits: Array<[string, t.ConfigValue]> = touched
       .filter((p) => p.startsWith('mcpServers.'))
       .map((p) => [p, editedValues[p]] as [string, t.ConfigValue]);
-    /** In scope mode, a leaf reset (undefined write) only removes the scope override and reveals the inherited base value, so feed configValues as the resetFallback. In base mode there is nothing to inherit from. */
+    /** A leaf reset (undefined write) removes the override and reveals the value of the next-lower layer. In scope mode that next layer is the base config; in base mode it is the un-merged YAML config (the baseOnly response). Feed whichever layer applies as the resetFallback so the cross-field validator does not falsely flag a reset-but-still-valid field as missing. */
     const mcpResetFallback = (() => {
-      if (!isEditingScope) return undefined;
-      const v = configValues?.mcpServers;
-      if (v && typeof v === 'object' && !Array.isArray(v)) {
-        return v as Record<string, t.ConfigValue>;
+      const source = isEditingScope ? configValues?.mcpServers : baseConfigData?.yamlMcpServers;
+      if (source && typeof source === 'object' && !Array.isArray(source)) {
+        return source as Record<string, t.ConfigValue>;
       }
       return undefined;
     })();
@@ -612,6 +611,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     saving,
     baseActiveConfigValues,
     configValues,
+    baseConfigData,
     localize,
   ]);
 

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -130,6 +130,21 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     return new Set(Object.keys(flattenObject(dbOverrides)));
   }, [dbOverrides]);
 
+  /**
+   * Authoritative set of YAML-defined entries per section, sourced from the
+   * un-merged baseOnly response. Identity affordances (rename, delete) are
+   * locked iff a name appears here, regardless of whether admin overrides
+   * also exist for it.
+   */
+  const baseRecordKeys = useMemo(() => {
+    const result: Record<string, Set<string>> = {};
+    const yamlMcpKeys = baseConfigData?.yamlMcpKeys;
+    if (yamlMcpKeys && Array.isArray(yamlMcpKeys)) {
+      result.mcpServers = new Set(yamlMcpKeys);
+    }
+    return result;
+  }, [baseConfigData]);
+
   const hasUnmappedSections = useMemo(
     () =>
       schemaTree.some(
@@ -344,41 +359,70 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     return scopeResolvedValues ?? {};
   }, [isEditingScope, flatBaseline, scopeResolvedValues]);
 
+  /**
+   * Every intermediate (non-leaf) path implied by the baseline's flat keys.
+   * Used by handleFieldChange to recognize "delete the whole subtree" writes
+   * whose target path doesn't itself appear in scopeBaseline because
+   * flatBaseline only stores leaf paths.
+   */
+  const baselineIntermediates = useMemo(() => {
+    const set = new Set<string>();
+    for (const leaf of Object.keys(scopeBaseline)) {
+      const parts = leaf.split('.');
+      for (let i = 1; i < parts.length; i++) {
+        set.add(parts.slice(0, i).join('.'));
+      }
+    }
+    return set;
+  }, [scopeBaseline]);
+
   const handleFieldChange = useCallback(
     (path: string, value: t.ConfigValue) => {
-      startTransition(() => {
-        setTouchedPaths((prev) => {
-          if (prev.has(path)) return prev;
-          const next = new Set(prev);
-          next.add(path);
+      setTouchedPaths((prev) => {
+        if (prev.has(path)) return prev;
+        const next = new Set(prev);
+        next.add(path);
+        return next;
+      });
+      setEditedValues((prev) => {
+        const baseline = scopeBaseline[path];
+        const match =
+          value === baseline ||
+          (typeof value === 'object' &&
+            typeof baseline === 'object' &&
+            JSON.stringify(value) === JSON.stringify(baseline));
+        /**
+         * Suppress the prune for undefined writes that target an intermediate
+         * container path. handleRemove/handleRename emit these to request
+         * "delete the whole subtree"; pruning would silently drop them
+         * because flatBaseline only stores leaf paths, so scopeBaseline at
+         * the container is always undefined and would falsely match.
+         */
+        const isContainerDelete = value === undefined && baselineIntermediates.has(path);
+        if (match && !isContainerDelete) {
+          const next = { ...prev };
+          delete next[path];
           return next;
-        });
-        setEditedValues((prev) => {
-          const baseline = scopeBaseline[path];
-          const match =
-            value === baseline ||
-            (typeof value === 'object' &&
-              typeof baseline === 'object' &&
-              JSON.stringify(value) === JSON.stringify(baseline));
-          if (match) {
-            const next = { ...prev };
-            delete next[path];
-            return next;
+        }
+        const next = { ...prev, [path]: value };
+        if (Array.isArray(value)) {
+          const prefix = `${path}.`;
+          for (const k of Object.keys(next)) {
+            if (k.startsWith(prefix) && /\.\d+$/.test(k)) delete next[k];
           }
-          const next = { ...prev, [path]: value };
-          if (Array.isArray(value)) {
-            const prefix = `${path}.`;
-            for (const k of Object.keys(next)) {
-              if (k.startsWith(prefix) && /\.\d+$/.test(k)) delete next[k];
-            }
+        }
+        const indexMatch = /^(.+)\.\d+$/.exec(path);
+        if (indexMatch) delete next[indexMatch[1]];
+        for (const existing of Object.keys(next)) {
+          if (existing === path) continue;
+          if (path.startsWith(`${existing}.`)) {
+            delete next[existing];
           }
-          const indexMatch = /^(.+)\.\d+$/.exec(path);
-          if (indexMatch) delete next[indexMatch[1]];
-          return next;
-        });
+        }
+        return next;
       });
     },
-    [scopeBaseline],
+    [scopeBaseline, baselineIntermediates],
   );
 
   const isDirty = Object.keys(editedValues).length > 0;
@@ -457,7 +501,9 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
       .filter((p) => editedValues[p] !== undefined)
       .map((p) => ({
         fieldPath: p,
-        value: /\.\d+$/.test(p) ? deepSerializeKVPairs(editedValues[p]) : serializeKVPairs(editedValues[p]),
+        value: /\.\d+$/.test(p)
+          ? deepSerializeKVPairs(editedValues[p])
+          : serializeKVPairs(editedValues[p]),
       }));
     const resets = touched.filter((p) => editedValues[p] === undefined);
 
@@ -540,7 +586,10 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
       const segments = path.split('.');
       let current: t.ConfigValue = configValues;
       for (const seg of segments) {
-        if (current == null || typeof current !== 'object') { current = undefined; break; }
+        if (current == null || typeof current !== 'object') {
+          current = undefined;
+          break;
+        }
         current = Array.isArray(current)
           ? (current as t.ConfigValue[])[Number(seg)]
           : (current as Record<string, t.ConfigValue>)[seg];
@@ -827,6 +876,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
               sectionPermissions={sectionPermissions}
               schemaDefaults={schemaDefaults}
               showConfiguredOnly={showConfiguredOnly}
+              baseRecordKeys={baseRecordKeys}
             />
           </div>
         </div>

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -616,7 +616,6 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     saving,
     baseActiveConfigValues,
     configValues,
-    isEditingScope,
     localize,
   ]);
 

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -35,6 +35,7 @@ import { StickyActionBar } from '@/components/shared';
 import { ConfigTabContent } from './ConfigTabContent';
 import { ImportYamlDialog } from './ImportYamlDialog';
 import { ContentToolbar } from './ContentToolbar';
+import { validateMcpCrossField } from './sections/McpServersRenderer';
 import { mergeIndexedArrayEdits } from './utils';
 import { SystemCapabilities } from '@/constants';
 import { ConfigTabBar } from './ConfigTabBar';
@@ -508,6 +509,31 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     const touched = [...touchedPaths].filter((p) => p in editedValues);
     if (touched.length === 0) return;
 
+    /** Per-leaf saves can land an MCP entry in a transport state whose required siblings are missing (e.g. type=stdio with no command/args). Server-side per-field validation only sees one path at a time, so do the cross-field check here against the merged effective entry before any PATCH fires. */
+    const mcpBaseline = (() => {
+      const v = configValues?.mcpServers;
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        return v as Record<string, t.ConfigValue>;
+      }
+      return {};
+    })();
+    const mcpEdits: Array<[string, t.ConfigValue]> = touched
+      .filter((p) => p.startsWith('mcpServers.'))
+      .map((p) => [p, editedValues[p]] as [string, t.ConfigValue]);
+    if (mcpEdits.length > 0) {
+      const mcpErrors = validateMcpCrossField(mcpBaseline, mcpEdits);
+      if (mcpErrors.length > 0) {
+        const { entryKey, missingField } = mcpErrors[0];
+        const message = localize('com_config_mcp_invalid_after_edit', {
+          entry: entryKey,
+          field: missingField,
+        });
+        setSaveError(message);
+        showToast({ type: 'error', message }, 5000);
+        return;
+      }
+    }
+
     const saves = touched
       .filter((p) => editedValues[p] !== undefined)
       .map((p) => ({
@@ -579,6 +605,8 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     invalidateAndResetBase,
     invalidateAndResetScope,
     saving,
+    configValues,
+    localize,
   ]);
 
   const serializedEditedValues = useMemo(() => {

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -558,6 +558,13 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
           : serializeKVPairs(editedValues[p]),
       }));
     const resets = touched.filter((p) => editedValues[p] === undefined);
+    const inheritedMcpKeys = (() => {
+      const source = isEditingScope ? configValues?.mcpServers : undefined;
+      if (source && typeof source === 'object' && !Array.isArray(source)) {
+        return new Set(Object.keys(source as Record<string, t.ConfigValue>));
+      }
+      return new Set<string>();
+    })();
 
     setSaving(true);
     setSaveError(null);
@@ -568,7 +575,10 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
       if (resets.length > 0) {
         const resetPromises = isEditingScope
           ? (() => {
-              const { resetPaths, tombstonePaths } = partitionScopeResetPaths(resets);
+              const { resetPaths, tombstonePaths } = partitionScopeResetPaths(
+                resets,
+                inheritedMcpKeys,
+              );
               return [
                 ...resetPaths.map((fieldPath) =>
                   removeFieldProfileValueFn({

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -130,12 +130,6 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     return new Set(Object.keys(flattenObject(dbOverrides)));
   }, [dbOverrides]);
 
-  /**
-   * Authoritative set of YAML-defined entries per section, sourced from the
-   * un-merged baseOnly response. Identity affordances (rename, delete) are
-   * locked iff a name appears here, regardless of whether admin overrides
-   * also exist for it.
-   */
   const baseRecordKeys = useMemo(() => {
     const result: Record<string, Set<string>> = {};
     const yamlMcpKeys = baseConfigData?.yamlMcpKeys;
@@ -359,12 +353,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     return scopeResolvedValues ?? {};
   }, [isEditingScope, flatBaseline, scopeResolvedValues]);
 
-  /**
-   * Every intermediate (non-leaf) path implied by the baseline's flat keys.
-   * Used by handleFieldChange to recognize "delete the whole subtree" writes
-   * whose target path doesn't itself appear in scopeBaseline because
-   * flatBaseline only stores leaf paths.
-   */
+  /** Container paths inferred from leaf baselines, used to tell apart subtree-deletes from no-op writes. */
   const baselineIntermediates = useMemo(() => {
     const set = new Set<string>();
     for (const leaf of Object.keys(scopeBaseline)) {
@@ -391,13 +380,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
           (typeof value === 'object' &&
             typeof baseline === 'object' &&
             JSON.stringify(value) === JSON.stringify(baseline));
-        /**
-         * Suppress the prune for undefined writes that target an intermediate
-         * container path. handleRemove/handleRename emit these to request
-         * "delete the whole subtree"; pruning would silently drop them
-         * because flatBaseline only stores leaf paths, so scopeBaseline at
-         * the container is always undefined and would falsely match.
-         */
+        /** A container-path undefined write must survive; baseline only stores leaves, so it would otherwise match `undefined === undefined` and get pruned. */
         const isContainerDelete = value === undefined && baselineIntermediates.has(path);
         if (match && !isContainerDelete) {
           const next = { ...prev };

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -403,11 +403,16 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
         const isContainerDelete =
           value === undefined &&
           (baselineIntermediates.has(path) || baselineContainerPaths.has(path));
-        /** When the user deleted a container entry and is now writing descendants under it (delete-then-recreate of an MCP server), the new leaf must persist even if it matches baseline so the post-DELETE recreate is not missing required fields, and the ancestor-undefined must outlive the descendant write so handleConfirmSave can DELETE the entry before PATCHing the new leaves. */
-        const hasPendingAncestorDelete = Object.keys(prev).some(
-          (existing) =>
-            existing !== path && path.startsWith(`${existing}.`) && prev[existing] === undefined,
-        );
+        /** When the user deleted a container entry and is now writing descendants under it (delete-then-recreate of an MCP server), the new leaf must persist even if it matches baseline so the post-DELETE recreate is not missing required fields, and the ancestor-undefined must outlive the descendant write so handleConfirmSave can DELETE the entry before PATCHing the new leaves. Walk ancestors directly instead of scanning every pending edit; rename/remove emit one onChange per leaf and the prior O(n)-per-call scan compounded to O(n*m) work per event. */
+        const hasPendingAncestorDelete = (() => {
+          let lastDot = path.lastIndexOf('.');
+          while (lastDot > 0) {
+            const ancestor = path.slice(0, lastDot);
+            if (ancestor in prev && prev[ancestor] === undefined) return true;
+            lastDot = ancestor.lastIndexOf('.');
+          }
+          return false;
+        })();
         if (match && !isContainerDelete && !hasPendingAncestorDelete) {
           const next = { ...prev };
           delete next[path];

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -889,6 +889,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
               showConfiguredOnly={showConfiguredOnly}
               baseRecordKeys={baseRecordKeys}
               onValidationError={(message) => showToast({ type: 'error', message }, 5000)}
+              scopeMode={isEditingScope}
             />
           </div>
         </div>

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -403,16 +403,14 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
         const isContainerDelete =
           value === undefined &&
           (baselineIntermediates.has(path) || baselineContainerPaths.has(path));
-        if (match && !isContainerDelete) {
+        /** When the user deleted a container entry and is now writing descendants under it (delete-then-recreate of an MCP server), the new leaf must persist even if it matches baseline so the post-DELETE recreate is not missing required fields, and the ancestor-undefined must outlive the descendant write so handleConfirmSave can DELETE the entry before PATCHing the new leaves. */
+        const hasPendingAncestorDelete = Object.keys(prev).some(
+          (existing) =>
+            existing !== path && path.startsWith(`${existing}.`) && prev[existing] === undefined,
+        );
+        if (match && !isContainerDelete && !hasPendingAncestorDelete) {
           const next = { ...prev };
           delete next[path];
-          /** Drop any orphaned ancestor `undefined` writes; a leaf returning to baseline means the user is re-asserting that subtree, so a stale "delete this whole entry" left over from a prior remove (e.g. delete-then-recreate-at-baseline) must not survive to hide the resurrected entry. */
-          for (const existing of Object.keys(next)) {
-            if (existing === path) continue;
-            if (path.startsWith(`${existing}.`) && next[existing] === undefined) {
-              delete next[existing];
-            }
-          }
           return next;
         }
         const next = { ...prev, [path]: value };
@@ -424,10 +422,13 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
         }
         const indexMatch = /^(.+)\.\d+$/.exec(path);
         if (indexMatch) delete next[indexMatch[1]];
-        /** Two-way dedup: drop ancestors that the new leaf supersedes AND descendants that the new parent supersedes. Without the descendant sweep, a rename's per-leaf writes plus a subsequent parent-level edit of the same subtree would both reach the field PATCH endpoint and race order-dependently against each other. */
+        /** Two-way dedup: drop ancestors that the new leaf supersedes AND descendants that the new parent supersedes. An ancestor whose value is `undefined` expresses "delete this whole subtree" and must outlive subsequent descendant writes so DELETE-then-PATCH ordering at save time can fully replace the entry instead of leaking stale fields. */
         for (const existing of Object.keys(next)) {
           if (existing === path) continue;
-          if (path.startsWith(`${existing}.`) || existing.startsWith(`${path}.`)) {
+          const newIsDescendant = path.startsWith(`${existing}.`);
+          const newIsAncestor = existing.startsWith(`${path}.`);
+          if (newIsDescendant && next[existing] === undefined) continue;
+          if (newIsDescendant || newIsAncestor) {
             delete next[existing];
           }
         }
@@ -558,41 +559,36 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     showToast({ type: 'saving' });
 
     try {
-      const promises: Promise<unknown>[] = [];
-
-      if (saves.length > 0) {
-        if (isEditingScope) {
-          promises.push(
-            bulkSaveProfileValuesFn({
-              data: {
-                principalType: editingScope!.principalType,
-                principalId: editingScope!.principalId,
-                entries: saves,
-              },
-            }),
-          );
-        } else {
-          promises.push(saveBaseConfigFn({ data: { entries: saves } }));
-        }
-      }
-
-      for (const fieldPath of resets) {
-        if (isEditingScope) {
-          promises.push(
-            removeFieldProfileValueFn({
+      /** Resets must land before saves so a delete-then-recreate at the same path (e.g. MCP entry replaced with different fields) wipes stale fields first and the new leaf PATCHes don't race against the DELETE. */
+      if (resets.length > 0) {
+        const resetPromises = resets.map((fieldPath) => {
+          if (isEditingScope) {
+            return removeFieldProfileValueFn({
               data: {
                 fieldPath,
                 principalType: editingScope!.principalType,
                 principalId: editingScope!.principalId,
               },
-            }),
-          );
-        } else {
-          promises.push(resetBaseConfigFieldFn({ data: { fieldPath } }));
-        }
+            });
+          }
+          return resetBaseConfigFieldFn({ data: { fieldPath } });
+        });
+        await Promise.all(resetPromises);
       }
 
-      await Promise.all(promises);
+      if (saves.length > 0) {
+        if (isEditingScope) {
+          await bulkSaveProfileValuesFn({
+            data: {
+              principalType: editingScope!.principalType,
+              principalId: editingScope!.principalId,
+              entries: saves,
+            },
+          });
+        } else {
+          await saveBaseConfigFn({ data: { entries: saves } });
+        }
+      }
 
       if (isEditingScope) {
         invalidateAndResetScope();

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -423,9 +423,10 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
         }
         const indexMatch = /^(.+)\.\d+$/.exec(path);
         if (indexMatch) delete next[indexMatch[1]];
+        /** Two-way dedup: drop ancestors that the new leaf supersedes AND descendants that the new parent supersedes. Without the descendant sweep, a rename's per-leaf writes plus a subsequent parent-level edit of the same subtree would both reach the field PATCH endpoint and race order-dependently against each other. */
         for (const existing of Object.keys(next)) {
           if (existing === path) continue;
-          if (path.startsWith(`${existing}.`)) {
+          if (path.startsWith(`${existing}.`) || existing.startsWith(`${path}.`)) {
             delete next[existing];
           }
         }

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -923,7 +923,6 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
               showConfiguredOnly={showConfiguredOnly}
               baseRecordKeys={baseRecordKeys}
               onValidationError={(message) => showToast({ type: 'error', message }, 5000)}
-              scopeMode={isEditingScope}
             />
           </div>
         </div>

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -877,6 +877,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
               schemaDefaults={schemaDefaults}
               showConfiguredOnly={showConfiguredOnly}
               baseRecordKeys={baseRecordKeys}
+              onValidationError={(message) => showToast({ type: 'error', message }, 5000)}
             />
           </div>
         </div>

--- a/src/components/configuration/ConfigTabContent.tsx
+++ b/src/components/configuration/ConfigTabContent.tsx
@@ -54,6 +54,7 @@ export function ConfigTabContent({
   sectionPermissions,
   schemaDefaults,
   showConfiguredOnly,
+  isEditingScope,
   baseRecordKeys,
   onValidationError,
 }: t.ConfigTabContentProps) {
@@ -182,6 +183,7 @@ export function ConfigTabContent({
       pendingResets,
       schemaDefaults,
       showConfiguredOnly,
+      isEditingScope,
       yamlBaseKeys: baseRecordKeys?.[dataKey],
       onValidationError,
     };

--- a/src/components/configuration/ConfigTabContent.tsx
+++ b/src/components/configuration/ConfigTabContent.tsx
@@ -56,7 +56,6 @@ export function ConfigTabContent({
   showConfiguredOnly,
   baseRecordKeys,
   onValidationError,
-  scopeMode,
 }: t.ConfigTabContentProps) {
   const localize = useLocalize();
   const fieldsDisabled = readOnly;
@@ -185,7 +184,6 @@ export function ConfigTabContent({
       showConfiguredOnly,
       yamlBaseKeys: baseRecordKeys?.[dataKey],
       onValidationError,
-      scopeMode,
     };
     return (
       <>

--- a/src/components/configuration/ConfigTabContent.tsx
+++ b/src/components/configuration/ConfigTabContent.tsx
@@ -56,6 +56,7 @@ export function ConfigTabContent({
   showConfiguredOnly,
   baseRecordKeys,
   onValidationError,
+  scopeMode,
 }: t.ConfigTabContentProps) {
   const localize = useLocalize();
   const fieldsDisabled = readOnly;
@@ -184,6 +185,7 @@ export function ConfigTabContent({
       showConfiguredOnly,
       yamlBaseKeys: baseRecordKeys?.[dataKey],
       onValidationError,
+      scopeMode,
     };
     return (
       <>

--- a/src/components/configuration/ConfigTabContent.tsx
+++ b/src/components/configuration/ConfigTabContent.tsx
@@ -55,6 +55,7 @@ export function ConfigTabContent({
   schemaDefaults,
   showConfiguredOnly,
   baseRecordKeys,
+  onValidationError,
 }: t.ConfigTabContentProps) {
   const localize = useLocalize();
   const fieldsDisabled = readOnly;
@@ -182,6 +183,7 @@ export function ConfigTabContent({
       schemaDefaults,
       showConfiguredOnly,
       yamlBaseKeys: baseRecordKeys?.[dataKey],
+      onValidationError,
     };
     return (
       <>

--- a/src/components/configuration/ConfigTabContent.tsx
+++ b/src/components/configuration/ConfigTabContent.tsx
@@ -54,6 +54,7 @@ export function ConfigTabContent({
   sectionPermissions,
   schemaDefaults,
   showConfiguredOnly,
+  baseRecordKeys,
 }: t.ConfigTabContentProps) {
   const localize = useLocalize();
   const fieldsDisabled = readOnly;
@@ -164,6 +165,7 @@ export function ConfigTabContent({
       getValue,
       onChange: onFieldChange,
       onResetField,
+      editedValues,
       disabled: sectionDisabled,
       profileMap,
       previewMode,
@@ -179,6 +181,7 @@ export function ConfigTabContent({
       pendingResets,
       schemaDefaults,
       showConfiguredOnly,
+      yamlBaseKeys: baseRecordKeys?.[dataKey],
     };
     return (
       <>
@@ -232,7 +235,7 @@ export function ConfigTabContent({
   const isInlineSection = (section: t.ConfigSectionConfig): boolean =>
     Boolean(
       (section.sectionField && isSimpleScalar(section.sectionField)) ||
-        (section.fields.length === 1 && isSimpleScalar(section.fields[0])),
+      (section.fields.length === 1 && isSimpleScalar(section.fields[0])),
     );
 
   type SectionGroup =

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -698,7 +698,8 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
       for (let i = 0; i < leafEdits.length; i++) {
         const edit = leafEdits[i];
         if (edit.segments.length === 0) {
-          if (edit.value === undefined) {
+          /** `null` is the scope-mode tombstone shape; semantically equivalent to a delete from the view perspective. */
+          if (edit.value === undefined || edit.value === null) {
             seed = {};
             seedFromDelete = true;
           } else {
@@ -780,6 +781,11 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     localizeRef.current = localize;
   }, [localize]);
 
+  const scopeModeRef = useRef(scopeMode);
+  useEffect(() => {
+    scopeModeRef.current = scopeMode;
+  }, [scopeMode]);
+
   const handleCreate = useCallback(
     (serverName: string, entry: Record<string, t.ConfigValue>) => {
       if (serverName.includes('.')) {
@@ -837,9 +843,9 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           if (!seen.has(leafPath)) onChange(leafPath, undefined);
         }
       }
-      /** Entry-path delete is needed to make MongoDB's $unset collapse the subtree; per-leaf $unset alone leaves an empty parent that refetches as a phantom entry. */
+      /** In scope mode write `null` instead of `undefined`: undefined routes through the DELETE-field-path endpoint and silently no-ops for inherited entries that have no scope override, whereas `null` PATCHes a tombstone the merge layer recognizes as "hide this entry for this scope." Base mode keeps `undefined` so MongoDB's $unset can collapse the subtree. */
       if (!seen.has(entryPath)) {
-        onChange(entryPath, undefined);
+        onChange(entryPath, scopeModeRef.current ? null : undefined);
       }
     },
     [onChange, path],
@@ -900,8 +906,8 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         }
         onChange(`${oldPrefix}${segments.join('.')}`, undefined);
       }
-      /** See $unset note in handleRemove. */
-      onChange(`${path}.${oldKey}`, undefined);
+      /** See tombstone note in handleRemove for why scope mode writes null instead of undefined. */
+      onChange(`${path}.${oldKey}`, scopeModeRef.current ? null : undefined);
     },
     [onChange, path],
   );
@@ -912,18 +918,13 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         <button
           type="button"
           onClick={() => setCreateOpen(true)}
-          disabled={disabled || scopeMode}
+          disabled={disabled}
           className="config-add-btn"
         >
           <Icon name="plus" size="sm" />
           <span>{localize('com_config_create_mcp_server')}</span>
         </button>
       </div>
-      {scopeMode && (
-        <p className="text-sm text-(--cui-color-text-muted)">
-          {localize('com_config_mcp_scope_structural_disabled')}
-        </p>
-      )}
       {entries.map(([key, entryValue]) => (
         <McpEntryRow
           key={key}
@@ -933,7 +934,6 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           path={path}
           disabled={disabled}
           isYamlSource={yamlSourceKeys.has(key)}
-          scopeMode={scopeMode}
           onChange={onChange}
           onRemove={handleRemove}
           onRename={handleRename}
@@ -972,7 +972,6 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   path,
   disabled,
   isYamlSource,
-  scopeMode,
   onChange,
   onRemove,
   onRename,
@@ -984,7 +983,6 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   path: string;
   disabled?: boolean;
   isYamlSource: boolean;
-  scopeMode?: boolean;
   onChange: (path: string, value: t.ConfigValue) => void;
   onRemove: (key: string) => void;
   onRename: (oldKey: string, newKey: string) => void;
@@ -1002,7 +1000,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   const isDottedLegacy = entryKey.includes('.');
   const isReadOnly = !!disabled || isDottedLegacy;
   /** Scope mode can't tombstone an inherited entry through per-leaf saves alone, so rename/delete are unreachable until the backend grows tombstone support; field edits still produce per-leaf scope overrides as expected. */
-  const isLockedIdentity = isYamlSource || isDottedLegacy || !!scopeMode;
+  const isLockedIdentity = isYamlSource || isDottedLegacy;
   const lockedKeys = isYamlSource && !isDottedLegacy ? YAML_LOCKED_FIELDS : undefined;
 
   const entryOnChange = useCallback(

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -657,7 +657,6 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     editedValues,
     yamlBaseKeys,
     onValidationError,
-    scopeMode,
   } = props;
   const localize = useLocalize();
   const [createOpen, setCreateOpen] = useState(false);
@@ -698,8 +697,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
       for (let i = 0; i < leafEdits.length; i++) {
         const edit = leafEdits[i];
         if (edit.segments.length === 0) {
-          /** `null` is the scope-mode tombstone shape; semantically equivalent to a delete from the view perspective. */
-          if (edit.value === undefined || edit.value === null) {
+          if (edit.value === undefined) {
             seed = {};
             seedFromDelete = true;
           } else {
@@ -781,11 +779,6 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     localizeRef.current = localize;
   }, [localize]);
 
-  const scopeModeRef = useRef(scopeMode);
-  useEffect(() => {
-    scopeModeRef.current = scopeMode;
-  }, [scopeMode]);
-
   const handleCreate = useCallback(
     (serverName: string, entry: Record<string, t.ConfigValue>) => {
       if (serverName.includes('.')) {
@@ -843,9 +836,9 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           if (!seen.has(leafPath)) onChange(leafPath, undefined);
         }
       }
-      /** In scope mode write `null` instead of `undefined`: undefined routes through the DELETE-field-path endpoint and silently no-ops for inherited entries that have no scope override, whereas `null` PATCHes a tombstone the merge layer recognizes as "hide this entry for this scope." Base mode keeps `undefined` so MongoDB's $unset can collapse the subtree. */
+      /** Entry-path delete is needed to make MongoDB's $unset collapse the subtree; per-leaf $unset alone leaves an empty parent that refetches as a phantom entry. */
       if (!seen.has(entryPath)) {
-        onChange(entryPath, scopeModeRef.current ? null : undefined);
+        onChange(entryPath, undefined);
       }
     },
     [onChange, path],
@@ -906,8 +899,8 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         }
         onChange(`${oldPrefix}${segments.join('.')}`, undefined);
       }
-      /** See tombstone note in handleRemove for why scope mode writes null instead of undefined. */
-      onChange(`${path}.${oldKey}`, scopeModeRef.current ? null : undefined);
+      /** See $unset note in handleRemove. */
+      onChange(`${path}.${oldKey}`, undefined);
     },
     [onChange, path],
   );

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -1075,10 +1075,23 @@ function splitMcpEntryPath(
   return { entryKey: rest.slice(0, dotIdx), field: rest.slice(dotIdx + 1) };
 }
 
-/** Merges leaf edits onto the baseline MCP entries (omitting deleted entries) so callers can validate the post-save state. */
+function lookupLeaf(
+  obj: unknown,
+  segments: string[],
+): t.ConfigValue | undefined {
+  let cursor: unknown = obj;
+  for (const seg of segments) {
+    if (!cursor || typeof cursor !== 'object' || Array.isArray(cursor)) return undefined;
+    cursor = (cursor as Record<string, unknown>)[seg];
+  }
+  return cursor as t.ConfigValue | undefined;
+}
+
+/** Merges leaf edits onto the baseline MCP entries (omitting deleted entries) so callers can validate the post-save state. `resetFallback`, when provided, supplies the value that an `undefined` leaf write would reveal after the actual save (e.g. in scope mode, a leaf reset removes the scope override and exposes the inherited base value). */
 export function mergeMcpEdits(
   baseline: Record<string, t.ConfigValue>,
   edits: Array<[string, t.ConfigValue]>,
+  resetFallback?: Record<string, t.ConfigValue>,
 ): Record<string, t.ConfigValue> {
   const baseEntries: Record<string, Record<string, t.ConfigValue>> = {};
   for (const [k, v] of Object.entries(baseline)) {
@@ -1095,9 +1108,15 @@ export function mergeMcpEdits(
     knownKeys.add(entryKey);
     if (field === '') {
       if (value === undefined) {
-        deletedEntries.add(entryKey);
-        delete upsertEntries[entryKey];
-        delete baseEntries[entryKey];
+        const fallback = resetFallback?.[entryKey];
+        if (isPlainObject(fallback)) {
+          upsertEntries[entryKey] = JSON.parse(JSON.stringify(fallback));
+          deletedEntries.delete(entryKey);
+        } else {
+          deletedEntries.add(entryKey);
+          delete upsertEntries[entryKey];
+          delete baseEntries[entryKey];
+        }
       } else if (isPlainObject(value)) {
         upsertEntries[entryKey] = JSON.parse(JSON.stringify(value));
         deletedEntries.delete(entryKey);
@@ -1110,7 +1129,13 @@ export function mergeMcpEdits(
     if (!upsertEntries[entryKey]) {
       upsertEntries[entryKey] = baseEntries[entryKey] ?? {};
     }
-    setLeaf(upsertEntries[entryKey], field.split('.'), value);
+    const segments = field.split('.');
+    if (value === undefined && resetFallback) {
+      const inherited = lookupLeaf(resetFallback[entryKey], segments);
+      setLeaf(upsertEntries[entryKey], segments, inherited as t.ConfigValue);
+    } else {
+      setLeaf(upsertEntries[entryKey], segments, value);
+    }
   }
 
   const result: Record<string, t.ConfigValue> = {};
@@ -1126,12 +1151,13 @@ export function mergeMcpEdits(
   return result;
 }
 
-/** Returns a list of validation errors for affected MCP entries after applying edits, so the save flow can block invalid transport-state combinations the per-leaf PATCH cannot catch. */
+/** Returns a list of validation errors for affected MCP entries after applying edits, so the save flow can block invalid transport-state combinations the per-leaf PATCH cannot catch. `resetFallback` is the inherited baseline (e.g. base config in scope mode) whose values get revealed when a scope reset removes an override. */
 export function validateMcpCrossField(
   baseline: Record<string, t.ConfigValue>,
   edits: Array<[string, t.ConfigValue]>,
+  resetFallback?: Record<string, t.ConfigValue>,
 ): Array<{ entryKey: string; missingField: string }> {
-  const merged = mergeMcpEdits(baseline, edits);
+  const merged = mergeMcpEdits(baseline, edits, resetFallback);
   const knownKeys = new Set(Object.keys(baseline));
   const affected = new Set<string>();
   for (const [path] of edits) {

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -794,14 +794,13 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         onValidationErrorRef.current?.(localizeRef.current('com_config_server_name_invalid'));
         return;
       }
+      /** Empty arrays are valid Zod values for required array fields (e.g. stdio `args: []`); skipping them here would drop the per-leaf write and leave the entry incomplete, failing the cross-field check at save time. Only undefined / null / empty string get filtered, matching what the dialog draft-trim already does. */
       for (const [fieldKey, fieldValue] of Object.entries(entry)) {
         if (fieldValue === undefined || fieldValue === null) continue;
         if (fieldValue === '') continue;
-        if (Array.isArray(fieldValue) && fieldValue.length === 0) continue;
         if (isPlainObject(fieldValue)) {
           for (const { segments, value } of enumerateLeafPaths(fieldValue, [fieldKey])) {
             if (value === undefined || value === null || value === '') continue;
-            if (Array.isArray(value) && value.length === 0) continue;
             onChange(`${path}.${serverName}.${segments.join('.')}`, value);
           }
         } else {

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -589,6 +589,25 @@ function CreateMcpServerDialog({
       if (Array.isArray(val) && val.length === 0) continue;
       entry[key] = val;
     }
+    /** Per-leaf saves bypass whole-object Zod validation, so a partial create (e.g. transport `sse` with no url) would persist as an invalid server. Validate transport-specific required fields here while we still hold the dialog draft. */
+    const rawType = typeof entry.type === 'string' ? entry.type : '';
+    const transportType = rawType || inferTransportType(entry);
+    const normalizedTransport = transportType === 'http' ? 'streamable-http' : transportType;
+    const required = REQUIRED_BY_TRANSPORT[normalizedTransport];
+    if (required) {
+      for (const field of required) {
+        const val = entry[field];
+        const missing =
+          val === undefined ||
+          val === null ||
+          val === '' ||
+          (Array.isArray(val) && val.length === 0);
+        if (missing) {
+          setError(localize('com_config_server_missing_required', { field }));
+          return;
+        }
+      }
+    }
     onSave(name, entry);
     setServerName('');
     setDraft({});

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -683,36 +683,44 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
   const record = useMemo(() => {
     if (editsByEntry.size === 0) return baseRecord;
     const result: Record<string, t.ConfigValue> = {};
-    for (const [k, v] of Object.entries(baseRecord)) {
-      if (!editsByEntry.has(k)) {
-        result[k] = v;
-      }
-    }
-    for (const [entryKey, leafEdits] of editsByEntry) {
+    /** Resolves a single entry's overlay value or `undefined` when the entry should drop out (whole-entry delete with no resurrecting writes). */
+    const resolveEntryValue = (
+      entryKey: string,
+      leafEdits: Array<{ segments: string[]; value: t.ConfigValue }>,
+    ): t.ConfigValue | undefined => {
       const wholeEntryWrites = leafEdits.filter((e) => e.segments.length === 0);
       const leafWrites = leafEdits.filter((e) => e.segments.length > 0);
-
       let current: t.ConfigValue | undefined;
       if (wholeEntryWrites.length > 0) {
         const last = wholeEntryWrites[wholeEntryWrites.length - 1];
-        if (last.value === undefined) {
-          continue;
-        }
+        if (last.value === undefined) return undefined;
         current = last.value;
       } else if (entryKey in baseRecord) {
         current = baseRecord[entryKey];
       }
-
-      if (leafWrites.length === 0) {
-        if (current !== undefined) result[entryKey] = current;
-        continue;
-      }
+      if (leafWrites.length === 0) return current;
       const existingObj = isPlainObject(current) ? current : {};
-      const overlay = applyLeafOverlay(
+      return applyLeafOverlay(
         existingObj,
         leafWrites.map((e) => [e.segments, e.value] as [string[], t.ConfigValue]),
       );
-      result[entryKey] = overlay;
+    };
+
+    /** Walk baseRecord first so edited entries keep their original position in the list instead of jumping to the bottom. */
+    for (const [k, v] of Object.entries(baseRecord)) {
+      const leafEdits = editsByEntry.get(k);
+      if (!leafEdits) {
+        result[k] = v;
+        continue;
+      }
+      const resolved = resolveEntryValue(k, leafEdits);
+      if (resolved !== undefined) result[k] = resolved;
+    }
+    /** Newly-created entries appear in editsByEntry insertion order at the bottom. */
+    for (const [entryKey, leafEdits] of editsByEntry) {
+      if (entryKey in baseRecord) continue;
+      const resolved = resolveEntryValue(entryKey, leafEdits);
+      if (resolved !== undefined) result[entryKey] = resolved;
     }
     return result;
   }, [baseRecord, editsByEntry]);

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -894,9 +894,8 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
 
       for (const segKey of allSegKeys) {
         const segments = segKey.split('.');
-        const leafValue = overlayBySeg.get(segKey);
-        if (leafValue !== undefined) {
-          onChange(`${newPrefix}${segments.join('.')}`, leafValue);
+        if (overlayBySeg.has(segKey)) {
+          onChange(`${newPrefix}${segments.join('.')}`, overlayBySeg.get(segKey));
         }
         onChange(`${oldPrefix}${segments.join('.')}`, undefined);
       }
@@ -1088,7 +1087,7 @@ function lookupLeaf(
 }
 
 /** Merges leaf edits onto the baseline MCP entries (omitting deleted entries) so callers can validate the post-save state. `resetFallback`, when provided, supplies the value that an `undefined` leaf write would reveal after the actual save (e.g. in scope mode, a leaf reset removes the scope override and exposes the inherited base value). */
-export function mergeMcpEdits(
+function mergeMcpEdits(
   baseline: Record<string, t.ConfigValue>,
   edits: Array<[string, t.ConfigValue]>,
   resetFallback?: Record<string, t.ConfigValue>,
@@ -1127,7 +1126,9 @@ export function mergeMcpEdits(
       deletedEntries.delete(entryKey);
     }
     if (!upsertEntries[entryKey]) {
-      upsertEntries[entryKey] = baseEntries[entryKey] ?? {};
+      /** Clone on promote so subsequent setLeaf mutations don't bleed into baseEntries; the assembly loop relies on baseEntries staying intact for entries that never received an upsert. */
+      const seed = baseEntries[entryKey];
+      upsertEntries[entryKey] = seed ? deepClone(seed) : {};
     }
     const segments = field.split('.');
     if (value === undefined && resetFallback) {
@@ -1189,10 +1190,4 @@ export function validateMcpCrossField(
   return errors;
 }
 
-export {
-  YAML_LOCKED_FIELDS,
-  INSPECTOR_DERIVED,
-  REQUIRED_BY_TRANSPORT,
-  inferTransportType,
-  enumerateLeafPaths,
-};
+export { YAML_LOCKED_FIELDS, INSPECTOR_DERIVED, enumerateLeafPaths };

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -657,6 +657,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     disabled,
     editedValues,
     yamlBaseKeys,
+    isEditingScope,
     onValidationError,
   } = props;
   const localize = useLocalize();
@@ -926,6 +927,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           fields={fields}
           path={path}
           disabled={disabled}
+          isEditingScope={!!isEditingScope}
           isYamlSource={yamlSourceKeys.has(key)}
           onChange={onChange}
           onRemove={handleRemove}
@@ -964,6 +966,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   fields,
   path,
   disabled,
+  isEditingScope,
   isYamlSource,
   onChange,
   onRemove,
@@ -975,6 +978,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   fields: t.SchemaField[];
   path: string;
   disabled?: boolean;
+  isEditingScope: boolean;
   isYamlSource: boolean;
   onChange: (path: string, value: t.ConfigValue) => void;
   onRemove: (key: string) => void;
@@ -992,8 +996,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   /** Dotted entry names predate the dot-rejecting create/rename validators; the save endpoint parses fieldPath as dot-delimited so any per-leaf write under such a key collides with a parallel "legacy" → "dotted" nested-object interpretation. Render them read-only so they stay visible in the list but never round-trip through the per-field save API. */
   const isDottedLegacy = entryKey.includes('.');
   const isReadOnly = !!disabled || isDottedLegacy;
-  /** Scope mode can't tombstone an inherited entry through per-leaf saves alone, so rename/delete are unreachable until the backend grows tombstone support; field edits still produce per-leaf scope overrides as expected. */
-  const isLockedIdentity = isYamlSource || isDottedLegacy;
+  const isLockedIdentity = (!isEditingScope && isYamlSource) || isDottedLegacy;
   const lockedKeys = isYamlSource && !isDottedLegacy ? YAML_LOCKED_FIELDS : undefined;
 
   const entryOnChange = useCallback(

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -123,6 +123,27 @@ function isPlainObject(value: t.ConfigValue): value is Record<string, t.ConfigVa
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/** New entry names are blocked from containing dots, but legacy data may still hold dotted server names; longest-prefix match against known keys keeps those edits attributed to the real entry instead of carving off the first segment. */
+function resolveEntryKey(
+  rest: string,
+  knownKeys: Iterable<string>,
+): { entryKey: string; segments: string[] } | null {
+  if (rest === '') return null;
+  let best: string | null = null;
+  for (const key of knownKeys) {
+    if (rest === key || rest.startsWith(`${key}.`)) {
+      if (best === null || key.length > best.length) best = key;
+    }
+  }
+  if (best !== null) {
+    const remainder = rest.length > best.length ? rest.slice(best.length + 1) : '';
+    return { entryKey: best, segments: remainder === '' ? [] : remainder.split('.') };
+  }
+  const dotIdx = rest.indexOf('.');
+  if (dotIdx === -1) return { entryKey: rest, segments: [] };
+  return { entryKey: rest.slice(0, dotIdx), segments: rest.slice(dotIdx + 1).split('.') };
+}
+
 function enumerateLeafPaths(
   obj: Record<string, t.ConfigValue>,
   prefix: string[] = [],
@@ -646,19 +667,18 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
   const editsByEntry = useMemo(() => {
     const map = new Map<string, Array<{ segments: string[]; value: t.ConfigValue }>>();
     if (!editedValues) return map;
+    const knownKeys = Object.keys(baseRecord);
     for (const [editPath, value] of Object.entries(editedValues)) {
       if (!editPath.startsWith(entryPrefix)) continue;
       const rest = editPath.slice(entryPrefix.length);
-      const parts = rest.split('.');
-      const entryKey = parts[0];
-      if (!entryKey) continue;
-      const segments = parts.slice(1);
-      const list = map.get(entryKey) ?? [];
-      list.push({ segments, value });
-      map.set(entryKey, list);
+      const parsed = resolveEntryKey(rest, knownKeys);
+      if (!parsed) continue;
+      const list = map.get(parsed.entryKey) ?? [];
+      list.push({ segments: parsed.segments, value });
+      map.set(parsed.entryKey, list);
     }
     return map;
-  }, [editedValues, entryPrefix]);
+  }, [editedValues, entryPrefix, baseRecord]);
 
   const record = useMemo(() => {
     if (editsByEntry.size === 0) return baseRecord;

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -80,18 +80,12 @@ function setLeaf(
   let cursor: Record<string, t.ConfigValue> = target;
   for (let i = 0; i < segments.length - 1; i++) {
     const seg = segments[i];
-    const next = cursor[seg];
-    if (next == null || typeof next !== 'object' || Array.isArray(next)) {
-      cursor[seg] = {};
-    }
+    if (!isPlainObject(cursor[seg])) cursor[seg] = {};
     cursor = cursor[seg] as Record<string, t.ConfigValue>;
   }
   const leaf = segments[segments.length - 1];
-  if (value === undefined) {
-    delete cursor[leaf];
-  } else {
-    cursor[leaf] = value;
-  }
+  if (value === undefined) delete cursor[leaf];
+  else cursor[leaf] = value;
 }
 
 function applyLeafOverlay(
@@ -1081,23 +1075,6 @@ function splitMcpEntryPath(
   return { entryKey: rest.slice(0, dotIdx), field: rest.slice(dotIdx + 1) };
 }
 
-function setLeafByPath(
-  target: Record<string, t.ConfigValue>,
-  segments: string[],
-  value: t.ConfigValue,
-): void {
-  let cursor: Record<string, t.ConfigValue> = target;
-  for (let i = 0; i < segments.length - 1; i++) {
-    const seg = segments[i];
-    const next = cursor[seg];
-    if (!isPlainObject(next)) cursor[seg] = {};
-    cursor = cursor[seg] as Record<string, t.ConfigValue>;
-  }
-  const leaf = segments[segments.length - 1];
-  if (value === undefined) delete cursor[leaf];
-  else cursor[leaf] = value;
-}
-
 /** Merges leaf edits onto the baseline MCP entries (omitting deleted entries) so callers can validate the post-save state. */
 export function mergeMcpEdits(
   baseline: Record<string, t.ConfigValue>,
@@ -1133,7 +1110,7 @@ export function mergeMcpEdits(
     if (!upsertEntries[entryKey]) {
       upsertEntries[entryKey] = baseEntries[entryKey] ?? {};
     }
-    setLeafByPath(upsertEntries[entryKey], field.split('.'), value);
+    setLeaf(upsertEntries[entryKey], field.split('.'), value);
   }
 
   const result: Record<string, t.ConfigValue> = {};

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -687,26 +687,37 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
   const record = useMemo(() => {
     if (editsByEntry.size === 0) return baseRecord;
     const result: Record<string, t.ConfigValue> = {};
-    /** Resolves a single entry's overlay value or `undefined` when the entry should drop out (whole-entry delete with no resurrecting writes). */
+    /** Resolves a single entry's overlay value or `undefined` when the entry should drop out. Iterates edits in insertion order so a whole-entry delete followed by recreating per-leaf writes shows the new entry, not the deleted one. The seed is the most recent whole-entry write (`undefined` becomes an empty object so subsequent leaves attach to it); without a whole-entry write the seed is the baseRecord entry. */
     const resolveEntryValue = (
       entryKey: string,
       leafEdits: Array<{ segments: string[]; value: t.ConfigValue }>,
     ): t.ConfigValue | undefined => {
-      const wholeEntryWrites = leafEdits.filter((e) => e.segments.length === 0);
-      const leafWrites = leafEdits.filter((e) => e.segments.length > 0);
-      let current: t.ConfigValue | undefined;
-      if (wholeEntryWrites.length > 0) {
-        const last = wholeEntryWrites[wholeEntryWrites.length - 1];
-        if (last.value === undefined) return undefined;
-        current = last.value;
-      } else if (entryKey in baseRecord) {
-        current = baseRecord[entryKey];
+      let seed: t.ConfigValue | undefined = baseRecord[entryKey];
+      let seedFromDelete = false;
+      let seedIndex = -1;
+      for (let i = 0; i < leafEdits.length; i++) {
+        const edit = leafEdits[i];
+        if (edit.segments.length === 0) {
+          if (edit.value === undefined) {
+            seed = {};
+            seedFromDelete = true;
+          } else {
+            seed = edit.value;
+            seedFromDelete = false;
+          }
+          seedIndex = i;
+        }
       }
-      if (leafWrites.length === 0) return current;
-      const existingObj = isPlainObject(current) ? current : {};
+      const subsequentLeaves = leafEdits
+        .slice(seedIndex + 1)
+        .filter((e) => e.segments.length > 0);
+      if (subsequentLeaves.length === 0) {
+        return seedFromDelete ? undefined : seed;
+      }
+      const existingObj = isPlainObject(seed) ? seed : {};
       return applyLeafOverlay(
         existingObj,
-        leafWrites.map((e) => [e.segments, e.value] as [string[], t.ConfigValue]),
+        subsequentLeaves.map((e) => [e.segments, e.value] as [string[], t.ConfigValue]),
       );
     };
 
@@ -1041,29 +1052,6 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   );
 });
 
-/** Returns the entry key + field-path within it, or null if the path is not under mcpServers. */
-function splitMcpEntryPath(
-  fullPath: string,
-  knownEntryKeys: Iterable<string>,
-): { entryKey: string; field: string } | null {
-  if (!fullPath.startsWith('mcpServers.')) return null;
-  const rest = fullPath.slice('mcpServers.'.length);
-  if (rest === '') return null;
-  let best: string | null = null;
-  for (const key of knownEntryKeys) {
-    if (rest === key || rest.startsWith(`${key}.`)) {
-      if (best === null || key.length > best.length) best = key;
-    }
-  }
-  if (best !== null) {
-    const field = rest.length > best.length ? rest.slice(best.length + 1) : '';
-    return { entryKey: best, field };
-  }
-  const dotIdx = rest.indexOf('.');
-  if (dotIdx === -1) return { entryKey: rest, field: '' };
-  return { entryKey: rest.slice(0, dotIdx), field: rest.slice(dotIdx + 1) };
-}
-
 function lookupLeaf(
   obj: unknown,
   segments: string[],
@@ -1091,11 +1079,12 @@ function mergeMcpEdits(
   const upsertEntries: Record<string, Record<string, t.ConfigValue>> = {};
 
   for (const [path, value] of edits) {
-    const split = splitMcpEntryPath(path, knownKeys);
-    if (!split) continue;
-    const { entryKey, field } = split;
+    if (!path.startsWith('mcpServers.')) continue;
+    const parsed = resolveEntryKey(path.slice('mcpServers.'.length), knownKeys);
+    if (!parsed) continue;
+    const { entryKey, segments } = parsed;
     knownKeys.add(entryKey);
-    if (field === '') {
+    if (segments.length === 0) {
       if (value === undefined) {
         const fallback = resetFallback?.[entryKey];
         if (isPlainObject(fallback)) {
@@ -1120,7 +1109,6 @@ function mergeMcpEdits(
       const seed = baseEntries[entryKey];
       upsertEntries[entryKey] = seed ? deepClone(seed) : {};
     }
-    const segments = field.split('.');
     if (value === undefined && resetFallback) {
       const inherited = lookupLeaf(resetFallback[entryKey], segments);
       setLeaf(upsertEntries[entryKey], segments, inherited as t.ConfigValue);
@@ -1152,8 +1140,12 @@ export function validateMcpCrossField(
   const knownKeys = new Set(Object.keys(baseline));
   const affected = new Set<string>();
   for (const [path] of edits) {
-    const split = splitMcpEntryPath(path, knownKeys);
-    if (split) affected.add(split.entryKey);
+    if (!path.startsWith('mcpServers.')) continue;
+    const parsed = resolveEntryKey(path.slice('mcpServers.'.length), knownKeys);
+    if (parsed) {
+      knownKeys.add(parsed.entryKey);
+      affected.add(parsed.entryKey);
+    }
   }
   const errors: Array<{ entryKey: string; missingField: string }> = [];
   for (const entryKey of affected) {

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -41,6 +41,12 @@ const TRANSPORT_TYPE_OPTIONS: { label: string; value: string }[] = [
 
 const ALWAYS_REQUIRED = new Set(['type']);
 
+/** Stable empty record used as the fallback for `baseRecord`/`parentValue` when no data is available, so the downstream `useMemo` chain on `editsByEntry`/`record` does not re-fire on every render with a fresh `{}` literal. */
+const EMPTY_RECORD: Record<string, t.ConfigValue> = Object.freeze({}) as Record<
+  string,
+  t.ConfigValue
+>;
+
 /**
  * YAML configs can omit `type` because each transport schema (except
  * streamable-http) defaults from the discriminating fields. Mirror the
@@ -664,8 +670,8 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
 
   const path = parentPath;
   const entryPrefix = `${path}.`;
-  const baseValue = getValue(path, parentValue ?? {});
-  const baseRecord: Record<string, t.ConfigValue> = isPlainObject(baseValue) ? baseValue : {};
+  const baseValue = getValue(path, parentValue ?? EMPTY_RECORD);
+  const baseRecord: Record<string, t.ConfigValue> = isPlainObject(baseValue) ? baseValue : EMPTY_RECORD;
 
   const editsByEntry = useMemo(() => {
     const map = new Map<string, Array<{ segments: string[]; value: t.ConfigValue }>>();
@@ -930,7 +936,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           onChange={onChange}
           onRemove={handleRemove}
           onRename={handleRename}
-          justAddedKey={justAddedKey}
+          justAdded={key === justAddedKey}
         />
       ))}
       {entries.length === 0 && (
@@ -968,7 +974,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   onChange,
   onRemove,
   onRename,
-  justAddedKey,
+  justAdded,
 }: {
   entryKey: string;
   entryValue: t.ConfigValue;
@@ -979,7 +985,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   onChange: (path: string, value: t.ConfigValue) => void;
   onRemove: (key: string) => void;
   onRename: (oldKey: string, newKey: string) => void;
-  justAddedKey: string | null;
+  justAdded: boolean;
 }) {
   const entryObj = isPlainObject(entryValue) ? entryValue : {};
   const rawType = typeof entryObj.type === 'string' ? entryObj.type : '';
@@ -1037,7 +1043,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
       onRemove={isReadOnly || isLockedIdentity ? undefined : () => onRemove(entryKey)}
       onRename={isReadOnly || isLockedIdentity ? undefined : (renamed) => onRename(entryKey, renamed)}
       disabled={isReadOnly}
-      defaultExpanded={entryKey === justAddedKey}
+      defaultExpanded={justAdded}
       renderFields={renderEntryFields}
     />
   );

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -673,6 +673,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     editedValues,
     yamlBaseKeys,
     onValidationError,
+    scopeMode,
   } = props;
   const localize = useLocalize();
   const [createOpen, setCreateOpen] = useState(false);
@@ -917,13 +918,18 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         <button
           type="button"
           onClick={() => setCreateOpen(true)}
-          disabled={disabled}
+          disabled={disabled || scopeMode}
           className="config-add-btn"
         >
           <Icon name="plus" size="sm" />
           <span>{localize('com_config_create_mcp_server')}</span>
         </button>
       </div>
+      {scopeMode && (
+        <p className="text-sm text-(--cui-color-text-muted)">
+          {localize('com_config_mcp_scope_structural_disabled')}
+        </p>
+      )}
       {entries.map(([key, entryValue]) => (
         <McpEntryRow
           key={key}
@@ -933,6 +939,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           path={path}
           disabled={disabled}
           isYamlSource={yamlSourceKeys.has(key)}
+          scopeMode={scopeMode}
           onChange={onChange}
           onRemove={handleRemove}
           onRename={handleRename}
@@ -971,6 +978,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   path,
   disabled,
   isYamlSource,
+  scopeMode,
   onChange,
   onRemove,
   onRename,
@@ -982,6 +990,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   path: string;
   disabled?: boolean;
   isYamlSource: boolean;
+  scopeMode?: boolean;
   onChange: (path: string, value: t.ConfigValue) => void;
   onRemove: (key: string) => void;
   onRename: (oldKey: string, newKey: string) => void;
@@ -998,7 +1007,8 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   /** Dotted entry names predate the dot-rejecting create/rename validators; the save endpoint parses fieldPath as dot-delimited so any per-leaf write under such a key collides with a parallel "legacy" → "dotted" nested-object interpretation. Render them read-only so they stay visible in the list but never round-trip through the per-field save API. */
   const isDottedLegacy = entryKey.includes('.');
   const isReadOnly = !!disabled || isDottedLegacy;
-  const isLockedIdentity = isYamlSource || isDottedLegacy;
+  /** Scope mode can't tombstone an inherited entry through per-leaf saves alone, so rename/delete are unreachable until the backend grows tombstone support; field edits still produce per-leaf scope overrides as expected. */
+  const isLockedIdentity = isYamlSource || isDottedLegacy || !!scopeMode;
   const lockedKeys = isYamlSource && !isDottedLegacy ? YAML_LOCKED_FIELDS : undefined;
 
   const entryOnChange = useCallback(

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -100,17 +100,7 @@ function applyLeafOverlay(
 }
 
 function deepClone(value: Record<string, t.ConfigValue>): Record<string, t.ConfigValue> {
-  const result: Record<string, t.ConfigValue> = {};
-  for (const [k, v] of Object.entries(value)) {
-    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
-      result[k] = deepClone(v as Record<string, t.ConfigValue>);
-    } else if (Array.isArray(v)) {
-      result[k] = v.slice();
-    } else {
-      result[k] = v;
-    }
-  }
-  return result;
+  return JSON.parse(JSON.stringify(value)) as Record<string, t.ConfigValue>;
 }
 
 function isPlainObject(value: t.ConfigValue): value is Record<string, t.ConfigValue> {

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -576,10 +576,9 @@ function CreateMcpServerDialog({
     const entry: Record<string, t.ConfigValue> = {};
     for (const [key, val] of Object.entries(draft)) {
       if (val === '' || val === undefined || val === null) continue;
-      if (Array.isArray(val) && val.length === 0) continue;
       entry[key] = val;
     }
-    /** Per-leaf saves bypass whole-object Zod validation, so a partial create (e.g. transport `sse` with no url) would persist as an invalid server. Validate transport-specific required fields here while we still hold the dialog draft. */
+    /** Per-leaf saves bypass whole-object Zod validation, so a partial create (e.g. transport `sse` with no url) would persist as an invalid server. Validate transport-specific required fields here while we still hold the dialog draft. An empty array is a valid Zod value for required array fields like stdio `args` (the schema requires presence but accepts `[]`), so do not flag it as missing. */
     const rawType = typeof entry.type === 'string' ? entry.type : '';
     const transportType = rawType || inferTransportType(entry);
     const normalizedTransport = transportType === 'http' ? 'streamable-http' : transportType;
@@ -587,11 +586,7 @@ function CreateMcpServerDialog({
     if (required) {
       for (const field of required) {
         const val = entry[field];
-        const missing =
-          val === undefined ||
-          val === null ||
-          val === '' ||
-          (Array.isArray(val) && val.length === 0);
+        const missing = val === undefined || val === null || val === '';
         if (missing) {
           setError(localize('com_config_server_missing_required', { field }));
           return;
@@ -1162,11 +1157,8 @@ export function validateMcpCrossField(
     if (!required) continue;
     for (const field of required) {
       const v = entry[field];
-      const missing =
-        v === undefined ||
-        v === null ||
-        v === '' ||
-        (Array.isArray(v) && v.length === 0);
+      /** Empty array is a valid Zod value for required array fields like stdio `args` (the schema requires presence, not non-empty). Don't flag it as missing. */
+      const missing = v === undefined || v === null || v === '';
       if (missing) {
         errors.push({ entryKey, missingField: field });
         break;

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -1143,7 +1143,14 @@ export function validateMcpCrossField(
     const entry = merged[entryKey];
     if (!isPlainObject(entry)) continue;
     const rawType = typeof entry.type === 'string' ? entry.type : '';
-    const transportType = rawType || inferTransportType(entry);
+    /** When the user clears the field that was inferring transport on an inferred-stdio entry (no explicit `type`), `inferTransportType(entry)` collapses to '' and the validator would skip required-field checks. Fall back to the baseline's inference so a stdio-by-default server still trips the missing-command check after its discriminator gets cleared. */
+    const baselineEntry = isPlainObject(baseline[entryKey])
+      ? (baseline[entryKey] as Record<string, t.ConfigValue>)
+      : null;
+    const transportType =
+      rawType ||
+      inferTransportType(entry) ||
+      (baselineEntry ? inferTransportType(baselineEntry) : '');
     const normalized = transportType === 'http' ? 'streamable-http' : transportType;
     const required = REQUIRED_BY_TRANSPORT[normalized];
     if (!required) continue;

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -1058,6 +1058,134 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   );
 });
 
+/** Returns the entry key + field-path within it, or null if the path is not under mcpServers. */
+function splitMcpEntryPath(
+  fullPath: string,
+  knownEntryKeys: Iterable<string>,
+): { entryKey: string; field: string } | null {
+  if (!fullPath.startsWith('mcpServers.')) return null;
+  const rest = fullPath.slice('mcpServers.'.length);
+  if (rest === '') return null;
+  let best: string | null = null;
+  for (const key of knownEntryKeys) {
+    if (rest === key || rest.startsWith(`${key}.`)) {
+      if (best === null || key.length > best.length) best = key;
+    }
+  }
+  if (best !== null) {
+    const field = rest.length > best.length ? rest.slice(best.length + 1) : '';
+    return { entryKey: best, field };
+  }
+  const dotIdx = rest.indexOf('.');
+  if (dotIdx === -1) return { entryKey: rest, field: '' };
+  return { entryKey: rest.slice(0, dotIdx), field: rest.slice(dotIdx + 1) };
+}
+
+function setLeafByPath(
+  target: Record<string, t.ConfigValue>,
+  segments: string[],
+  value: t.ConfigValue,
+): void {
+  let cursor: Record<string, t.ConfigValue> = target;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    const next = cursor[seg];
+    if (!isPlainObject(next)) cursor[seg] = {};
+    cursor = cursor[seg] as Record<string, t.ConfigValue>;
+  }
+  const leaf = segments[segments.length - 1];
+  if (value === undefined) delete cursor[leaf];
+  else cursor[leaf] = value;
+}
+
+/** Merges leaf edits onto the baseline MCP entries (omitting deleted entries) so callers can validate the post-save state. */
+export function mergeMcpEdits(
+  baseline: Record<string, t.ConfigValue>,
+  edits: Array<[string, t.ConfigValue]>,
+): Record<string, t.ConfigValue> {
+  const baseEntries: Record<string, Record<string, t.ConfigValue>> = {};
+  for (const [k, v] of Object.entries(baseline)) {
+    if (isPlainObject(v)) baseEntries[k] = JSON.parse(JSON.stringify(v));
+  }
+  const knownKeys = new Set(Object.keys(baseEntries));
+  const deletedEntries = new Set<string>();
+  const upsertEntries: Record<string, Record<string, t.ConfigValue>> = {};
+
+  for (const [path, value] of edits) {
+    const split = splitMcpEntryPath(path, knownKeys);
+    if (!split) continue;
+    const { entryKey, field } = split;
+    knownKeys.add(entryKey);
+    if (field === '') {
+      if (value === undefined) {
+        deletedEntries.add(entryKey);
+        delete upsertEntries[entryKey];
+        delete baseEntries[entryKey];
+      } else if (isPlainObject(value)) {
+        upsertEntries[entryKey] = JSON.parse(JSON.stringify(value));
+        deletedEntries.delete(entryKey);
+      }
+      continue;
+    }
+    if (deletedEntries.has(entryKey) && value !== undefined) {
+      deletedEntries.delete(entryKey);
+    }
+    if (!upsertEntries[entryKey]) {
+      upsertEntries[entryKey] = baseEntries[entryKey] ?? {};
+    }
+    setLeafByPath(upsertEntries[entryKey], field.split('.'), value);
+  }
+
+  const result: Record<string, t.ConfigValue> = {};
+  for (const [k, v] of Object.entries(baseEntries)) {
+    if (deletedEntries.has(k)) continue;
+    if (k in upsertEntries) continue;
+    result[k] = v;
+  }
+  for (const [k, v] of Object.entries(upsertEntries)) {
+    if (deletedEntries.has(k)) continue;
+    result[k] = v;
+  }
+  return result;
+}
+
+/** Returns a list of validation errors for affected MCP entries after applying edits, so the save flow can block invalid transport-state combinations the per-leaf PATCH cannot catch. */
+export function validateMcpCrossField(
+  baseline: Record<string, t.ConfigValue>,
+  edits: Array<[string, t.ConfigValue]>,
+): Array<{ entryKey: string; missingField: string }> {
+  const merged = mergeMcpEdits(baseline, edits);
+  const knownKeys = new Set(Object.keys(baseline));
+  const affected = new Set<string>();
+  for (const [path] of edits) {
+    const split = splitMcpEntryPath(path, knownKeys);
+    if (split) affected.add(split.entryKey);
+  }
+  const errors: Array<{ entryKey: string; missingField: string }> = [];
+  for (const entryKey of affected) {
+    const entry = merged[entryKey];
+    if (!isPlainObject(entry)) continue;
+    const rawType = typeof entry.type === 'string' ? entry.type : '';
+    const transportType = rawType || inferTransportType(entry);
+    const normalized = transportType === 'http' ? 'streamable-http' : transportType;
+    const required = REQUIRED_BY_TRANSPORT[normalized];
+    if (!required) continue;
+    for (const field of required) {
+      const v = entry[field];
+      const missing =
+        v === undefined ||
+        v === null ||
+        v === '' ||
+        (Array.isArray(v) && v.length === 0);
+      if (missing) {
+        errors.push({ entryKey, missingField: field });
+        break;
+      }
+    }
+  }
+  return errors;
+}
+
 export {
   YAML_LOCKED_FIELDS,
   INSPECTOR_DERIVED,

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -6,12 +6,17 @@
  *  - Semantic field groups (Connection, Authentication, Server Options, Advanced)
  *  - A "Create MCP Server" dialog for adding new entries
  *  - TOC-compatible scroll targets via entry card IDs
+ *
+ * All edits write per-leaf paths (`mcpServers.<key>.<field>`) into editedValues
+ * so single-field reset, baseline-equality dirty pruning, and rename orphan
+ * cleanup all work uniformly.
  */
 
 import { Icon } from '@clickhouse/click-ui';
-import { useState, useCallback } from 'react';
+import { memo, useRef, useMemo, useState, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
 import type * as t from '@/types';
+import { YAML_LOCKED_FIELDS, INSPECTOR_DERIVED } from './mcpFieldMeta';
 import { useCollapsibleSection } from '../useCollapsibleSection';
 import { ObjectEntryCard } from '../fields/ObjectEntryCard';
 import { renderCollapsible } from '../renderCollapsible';
@@ -98,6 +103,86 @@ function withFieldOverrides(field: t.SchemaField, transportType: string): t.Sche
 }
 
 // ---------------------------------------------------------------------------
+// Per-leaf edit overlay helpers
+// ---------------------------------------------------------------------------
+
+function setLeaf(
+  target: Record<string, t.ConfigValue>,
+  segments: string[],
+  value: t.ConfigValue,
+): void {
+  let cursor: Record<string, t.ConfigValue> = target;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    const next = cursor[seg];
+    if (next == null || typeof next !== 'object' || Array.isArray(next)) {
+      cursor[seg] = {};
+    }
+    cursor = cursor[seg] as Record<string, t.ConfigValue>;
+  }
+  const leaf = segments[segments.length - 1];
+  if (value === undefined) {
+    delete cursor[leaf];
+  } else {
+    cursor[leaf] = value;
+  }
+}
+
+function applyLeafOverlay(
+  base: Record<string, t.ConfigValue>,
+  leafEdits: Array<[string[], t.ConfigValue]>,
+): Record<string, t.ConfigValue> {
+  const cloned = deepClone(base);
+  for (const [segments, value] of leafEdits) {
+    setLeaf(cloned, segments, value);
+  }
+  return cloned;
+}
+
+function deepClone(value: Record<string, t.ConfigValue>): Record<string, t.ConfigValue> {
+  const result: Record<string, t.ConfigValue> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      result[k] = deepClone(v as Record<string, t.ConfigValue>);
+    } else if (Array.isArray(v)) {
+      result[k] = v.slice();
+    } else {
+      result[k] = v;
+    }
+  }
+  return result;
+}
+
+function isPlainObject(value: t.ConfigValue): value is Record<string, t.ConfigValue> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Walks a nested record and returns one entry per leaf (primitive or array).
+ * Used by rename to enumerate every leaf path beneath an MCP entry so nested
+ * structures like `headers.Authorization` survive the rename intact instead of
+ * collapsing into one whole-object write.
+ */
+function enumerateLeafPaths(
+  obj: Record<string, t.ConfigValue>,
+  prefix: string[] = [],
+  seen: WeakSet<object> = new WeakSet(),
+): Array<{ segments: string[]; value: t.ConfigValue }> {
+  if (seen.has(obj)) return [];
+  seen.add(obj);
+  const out: Array<{ segments: string[]; value: t.ConfigValue }> = [];
+  for (const [k, v] of Object.entries(obj)) {
+    const next = [...prefix, k];
+    if (isPlainObject(v)) {
+      out.push(...enumerateLeafPaths(v, next, seen));
+    } else {
+      out.push({ segments: next, value: v });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Semantic field groups
 // ---------------------------------------------------------------------------
 
@@ -162,14 +247,13 @@ function flattenGroupFields(
   transportType: string,
   disabled?: boolean,
   collectionRenderOverrides?: Record<string, t.CollectionRenderFields>,
+  lockedKeys?: Set<string>,
 ): ReactNode[] {
-  const values =
-    typeof parentValue === 'object' && parentValue !== null && !Array.isArray(parentValue)
-      ? (parentValue as Record<string, t.ConfigValue>)
-      : {};
+  const values = isPlainObject(parentValue) ? parentValue : {};
 
   const nodes: ReactNode[] = [];
   for (const field of fields) {
+    const fieldDisabled = disabled || (lockedKeys?.has(field.key) ?? false);
     // Custom render for transport type select — curated options with lowercase labels.
     // When `type` is omitted (common in YAML configs), infer it from other fields
     // to mirror backend Zod union resolution.
@@ -194,7 +278,7 @@ function flattenGroupFields(
               value={displayValue}
               options={TRANSPORT_TYPE_OPTIONS}
               onChange={(v) => onChange(field.key, v)}
-              disabled={disabled}
+              disabled={fieldDisabled}
               aria-label={label}
             />
           </div>
@@ -205,10 +289,7 @@ function flattenGroupFields(
 
     if (field.children && field.children.length > 0 && !field.isArray && field.type !== 'record') {
       const nested = values[field.key];
-      const nestedObj =
-        typeof nested === 'object' && nested !== null && !Array.isArray(nested)
-          ? (nested as Record<string, t.ConfigValue>)
-          : {};
+      const nestedObj = isPlainObject(nested) ? nested : {};
       for (const child of field.children) {
         nodes.push(
           renderInlineField(
@@ -219,7 +300,7 @@ function flattenGroupFields(
               onChange(field.key, { ...nestedObj, [childKey]: childValue });
             },
             localize,
-            disabled,
+            fieldDisabled,
             collectionRenderOverrides,
             true,
           ),
@@ -233,7 +314,7 @@ function flattenGroupFields(
           parentPath,
           onChange,
           localize,
-          disabled,
+          fieldDisabled,
           collectionRenderOverrides,
           true,
         ),
@@ -298,6 +379,7 @@ function FieldGroup({
   disabled,
   defaultExpanded,
   transportType,
+  lockedKeys,
 }: {
   labelKey: string;
   fields: t.SchemaField[];
@@ -307,6 +389,7 @@ function FieldGroup({
   disabled?: boolean;
   defaultExpanded: boolean;
   transportType: string;
+  lockedKeys?: Set<string>;
 }) {
   const localize = useLocalize();
   const { isExpanded, hasEverExpanded, sectionRef, toggle } = useCollapsibleSection({
@@ -349,6 +432,8 @@ function FieldGroup({
             localize,
             transportType,
             disabled,
+            undefined,
+            lockedKeys,
           )}
         </div>,
       )}
@@ -366,18 +451,17 @@ function McpEntryFields({
   parentPath,
   onChange,
   disabled,
+  lockedKeys,
 }: {
   fields: t.SchemaField[];
   parentValue: t.ConfigValue;
   parentPath: string;
   onChange: (path: string, value: t.ConfigValue) => void;
   disabled?: boolean;
+  lockedKeys?: Set<string>;
 }) {
   const localize = useLocalize();
-  const values =
-    typeof parentValue === 'object' && parentValue !== null && !Array.isArray(parentValue)
-      ? (parentValue as Record<string, t.ConfigValue>)
-      : {};
+  const values = isPlainObject(parentValue) ? parentValue : {};
   const explicitType = typeof values.type === 'string' ? values.type : '';
   const currentType = explicitType || inferTransportType(values);
 
@@ -386,12 +470,11 @@ function McpEntryFields({
   const isRemote = REMOTE_TRANSPORTS.has(currentType);
   const visibleKeys = new Set<string>();
   for (const field of fields) {
-    // Transport-specific fields: only show if they belong to the current transport
+    if (INSPECTOR_DERIVED.has(field.key)) continue;
     if (ALL_TRANSPORT_KEYS.has(field.key)) {
       if (currentTransportFields.has(field.key)) {
         visibleKeys.add(field.key);
       }
-      // Auth fields: only show for remote transports
     } else if (REMOTE_ONLY_FIELDS.has(field.key)) {
       if (isRemote) {
         visibleKeys.add(field.key);
@@ -401,16 +484,6 @@ function McpEntryFields({
     }
   }
 
-  // When type changes, we only update the type field itself. Transport-specific
-  // fields from the old type are already hidden by the visibility logic above,
-  // so stale values are invisible. We intentionally avoid clearing them here
-  // because ObjectEntryCard.handleFieldChange captures a stale `value` snapshot
-  // per call — multiple synchronous onChange calls would lose all but the last.
-  const handleChange = (key: string, value: t.ConfigValue) => {
-    onChange(key, value);
-  };
-
-  // Filter fields through visibility, then organize into groups
   const fieldsByKey = new Map(fields.map((f) => [f.key, f]));
   const collectGroupKeys = (groups: FieldGroupDef[]): string[] =>
     groups.flatMap((g) => [...g.fields, ...(g.children ? collectGroupKeys(g.children) : [])]);
@@ -426,7 +499,6 @@ function McpEntryFields({
     const hasChildren = group.children && group.children.length > 0;
     const groupFields = resolveFields(group.fields);
 
-    // For parent groups with children, check if any child sub-group has visible fields
     if (hasChildren) {
       const childGroups = group.children!.filter((child) => resolveFields(child.fields).length > 0);
       if (childGroups.length === 0 && groupFields.length === 0) return null;
@@ -442,10 +514,12 @@ function McpEntryFields({
                 groupFields,
                 parentValue,
                 parentPath,
-                handleChange,
+                onChange,
                 localize,
                 currentType,
                 disabled,
+                undefined,
+                lockedKeys,
               )}
             </div>
           )}
@@ -456,10 +530,11 @@ function McpEntryFields({
               fields={resolveFields(child.fields)}
               parentValue={parentValue}
               parentPath={parentPath}
-              onChange={handleChange}
+              onChange={onChange}
               disabled={disabled}
               defaultExpanded={child.defaultExpanded}
               transportType={currentType}
+              lockedKeys={lockedKeys}
             />
           ))}
         </FieldGroupSection>
@@ -473,10 +548,11 @@ function McpEntryFields({
         fields={groupFields}
         parentValue={parentValue}
         parentPath={parentPath}
-        onChange={handleChange}
+        onChange={onChange}
         disabled={disabled}
         defaultExpanded={group.defaultExpanded}
         transportType={currentType}
+        lockedKeys={lockedKeys}
       />
     );
   };
@@ -490,10 +566,11 @@ function McpEntryFields({
           fields={ungrouped}
           parentValue={parentValue}
           parentPath={parentPath}
-          onChange={handleChange}
+          onChange={onChange}
           disabled={disabled}
           defaultExpanded={false}
           transportType={currentType}
+          lockedKeys={lockedKeys}
         />
       )}
     </div>
@@ -533,6 +610,14 @@ function CreateMcpServerDialog({
     const name = serverName.trim();
     if (!name) {
       setError(localize('com_config_server_name_required'));
+      return;
+    }
+    if (name.includes('.')) {
+      setError(localize('com_config_server_name_no_dots'));
+      return;
+    }
+    if (name === '__proto__' || name === 'constructor' || name === 'prototype') {
+      setError(localize('com_config_server_name_invalid'));
       return;
     }
     if (existingKeys.has(name)) {
@@ -603,71 +688,275 @@ function CreateMcpServerDialog({
 // ---------------------------------------------------------------------------
 
 export function McpServersRenderer(props: t.FieldRendererProps) {
-  const { fields, parentPath, parentValue, getValue, onChange, disabled } = props;
+  const {
+    fields,
+    parentPath,
+    parentValue,
+    getValue,
+    onChange,
+    disabled,
+    editedValues,
+    yamlBaseKeys,
+  } = props;
   const localize = useLocalize();
   const [createOpen, setCreateOpen] = useState(false);
   const [justAddedKey, setJustAddedKey] = useState<string | null>(null);
-
-  const renderGroupedMcpFields: t.CollectionRenderFields = useCallback(
-    (entryFields, entryValue, entryPath, entryOnChange) => (
-      <McpEntryFields
-        fields={entryFields}
-        parentValue={entryValue}
-        parentPath={entryPath}
-        onChange={entryOnChange}
-        disabled={disabled}
-      />
-    ),
-    [disabled],
-  );
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   const path = parentPath;
-  const value = getValue(path, parentValue ?? {});
-  const record =
-    value && typeof value === 'object' && !Array.isArray(value)
-      ? (value as Record<string, t.ConfigValue>)
-      : {};
-  const entries = Object.entries(record);
-  const existingKeys = new Set(Object.keys(record));
+  const entryPrefix = `${path}.`;
+  const baseValue = getValue(path, parentValue ?? {});
+  const baseRecord: Record<string, t.ConfigValue> = isPlainObject(baseValue) ? baseValue : {};
+
+  /**
+   * Group edited paths by their entry key. Per-leaf paths are
+   * `mcpServers.<key>.<...>`; the entry key is the first path segment after
+   * the renderer's parent path. We collect [segmentsAfterEntry, value] pairs
+   * keyed by entry name so the record overlay can apply edits per entry
+   * without re-walking the full edit map.
+   */
+  const editsByEntry = useMemo(() => {
+    const map = new Map<string, Array<{ segments: string[]; value: t.ConfigValue }>>();
+    if (!editedValues) return map;
+    for (const [editPath, value] of Object.entries(editedValues)) {
+      if (!editPath.startsWith(entryPrefix)) continue;
+      const rest = editPath.slice(entryPrefix.length);
+      const parts = rest.split('.');
+      const entryKey = parts[0];
+      if (!entryKey) continue;
+      const segments = parts.slice(1);
+      const list = map.get(entryKey) ?? [];
+      list.push({ segments, value });
+      map.set(entryKey, list);
+    }
+    return map;
+  }, [editedValues, entryPrefix]);
+
+  /**
+   * Effective record overlay: walks every per-leaf edit for each entry and
+   * applies it on top of the base value. Leaf undefined deletes the leaf;
+   * if every leaf under an entry is undefined and the entry has no remaining
+   * keys, the entry is removed from the rendered list. Entries with no edits
+   * are referenced by identity from `baseRecord` (no deep clone) so steady
+   * state does not pay for cloning unchanged data.
+   */
+  const record = useMemo(() => {
+    if (editsByEntry.size === 0) return baseRecord;
+    const result: Record<string, t.ConfigValue> = {};
+    for (const [k, v] of Object.entries(baseRecord)) {
+      if (!editsByEntry.has(k)) {
+        result[k] = v;
+      }
+    }
+    for (const [entryKey, leafEdits] of editsByEntry) {
+      // Whole-entry writes (empty segments) are kept for backward compatibility
+      // with the previous create/delete flows.
+      const wholeEntryWrites = leafEdits.filter((e) => e.segments.length === 0);
+      const leafWrites = leafEdits.filter((e) => e.segments.length > 0);
+
+      let current: t.ConfigValue | undefined;
+      if (wholeEntryWrites.length > 0) {
+        const last = wholeEntryWrites[wholeEntryWrites.length - 1];
+        if (last.value === undefined) {
+          continue;
+        }
+        current = last.value;
+      } else if (entryKey in baseRecord) {
+        current = baseRecord[entryKey];
+      }
+
+      if (leafWrites.length === 0) {
+        if (current !== undefined) result[entryKey] = current;
+        continue;
+      }
+      const existingObj = isPlainObject(current) ? current : {};
+      const overlay = applyLeafOverlay(
+        existingObj,
+        leafWrites.map((e) => [e.segments, e.value] as [string[], t.ConfigValue]),
+      );
+      result[entryKey] = overlay;
+    }
+    return result;
+  }, [baseRecord, editsByEntry]);
+
+  const entries = useMemo(() => Object.entries(record), [record]);
+
+  const existingKeys = useMemo(() => new Set(Object.keys(record)), [record]);
+
+  /**
+   * Server identity is locked iff the entry's name appears in the un-merged
+   * YAML/file base config (sourced via getBaseConfigFn's yamlMcpKeys).
+   *
+   * When the upstream YAML key set is unavailable (older LibreChat backend
+   * without ?baseOnly=true support), return an empty set so nothing is
+   * locked. That degrades to "everything editable" rather than to a
+   * subtraction heuristic which produced false positives on YAML servers
+   * with admin overrides on cosmetic fields like title or iconPath.
+   */
+  const yamlSourceKeys = useMemo(() => {
+    return yamlBaseKeys ?? new Set<string>();
+  }, [yamlBaseKeys]);
+
+  /**
+   * Refs let the create/remove/rename callbacks stay referentially stable so
+   * memo(McpEntryRow) actually bails on entries that didn't change. The refs
+   * shadow editedValues/baseRecord/record (each of which changes on every
+   * keystroke) and are read at call time from inside the callback bodies.
+   */
+  const editedValuesRef = useRef(editedValues);
+  useEffect(() => {
+    editedValuesRef.current = editedValues;
+  }, [editedValues]);
+
+  const baseRecordRef = useRef(baseRecord);
+  useEffect(() => {
+    baseRecordRef.current = baseRecord;
+  }, [baseRecord]);
+
+  const recordRef = useRef(record);
+  useEffect(() => {
+    recordRef.current = record;
+  }, [record]);
 
   const handleCreate = useCallback(
     (serverName: string, entry: Record<string, t.ConfigValue>) => {
-      const next: Record<string, t.ConfigValue> = { [serverName]: entry };
-      for (const [k, v] of entries) {
-        next[k] = v;
+      if (serverName.includes('.')) {
+        setValidationError(localize('com_config_server_name_no_dots'));
+        return;
       }
-      onChange(path, next);
+      if (
+        serverName === '__proto__' ||
+        serverName === 'constructor' ||
+        serverName === 'prototype'
+      ) {
+        setValidationError(localize('com_config_server_name_invalid'));
+        return;
+      }
+      for (const [fieldKey, fieldValue] of Object.entries(entry)) {
+        if (fieldValue === undefined || fieldValue === null) continue;
+        if (fieldValue === '') continue;
+        if (Array.isArray(fieldValue) && fieldValue.length === 0) continue;
+        if (isPlainObject(fieldValue)) {
+          for (const { segments, value } of enumerateLeafPaths(fieldValue, [fieldKey])) {
+            if (value === undefined || value === null || value === '') continue;
+            if (Array.isArray(value) && value.length === 0) continue;
+            onChange(`${path}.${serverName}.${segments.join('.')}`, value);
+          }
+        } else {
+          onChange(`${path}.${serverName}.${fieldKey}`, fieldValue);
+        }
+      }
+      setValidationError(null);
       setJustAddedKey(serverName);
     },
-    [entries, onChange, path],
+    [onChange, path, localize],
   );
 
   const handleRemove = useCallback(
     (key: string) => {
-      const next = { ...record };
-      delete next[key];
-      onChange(path, next);
+      const editedValues = editedValuesRef.current;
+      const baseRecord = baseRecordRef.current;
+      const prefix = `${path}.${key}.`;
+      const entryPath = `${path}.${key}`;
+      const seen = new Set<string>();
+      if (editedValues) {
+        for (const editPath of Object.keys(editedValues)) {
+          if (editPath.startsWith(prefix) || editPath === entryPath) {
+            onChange(editPath, undefined);
+            seen.add(editPath);
+          }
+        }
+      }
+      const baseEntry = baseRecord[key];
+      if (isPlainObject(baseEntry)) {
+        for (const { segments } of enumerateLeafPaths(baseEntry)) {
+          const leafPath = `${prefix}${segments.join('.')}`;
+          if (!seen.has(leafPath)) onChange(leafPath, undefined);
+        }
+      }
+      /**
+       * Also emit a delete at the entry path so MongoDB's $unset collapses
+       * the whole subtree. Per-leaf $unset alone leaves an empty parent
+       * object that refetches as a phantom server entry.
+       */
+      if (!seen.has(entryPath)) {
+        onChange(entryPath, undefined);
+      }
     },
-    [record, onChange, path],
+    [onChange, path],
   );
 
   const handleRename = useCallback(
     (oldKey: string, newKey: string) => {
-      if (newKey === oldKey || newKey in record) return;
-      const next: Record<string, t.ConfigValue> = {};
-      for (const [k, v] of Object.entries(record)) {
-        next[k === oldKey ? newKey : k] = v;
+      if (newKey === oldKey) {
+        setValidationError(null);
+        return;
       }
-      onChange(path, next);
-    },
-    [record, onChange, path],
-  );
+      const editedValues = editedValuesRef.current;
+      const baseRecord = baseRecordRef.current;
+      const record = recordRef.current;
+      if (newKey.includes('.')) {
+        setValidationError(localize('com_config_server_name_no_dots'));
+        return;
+      }
+      if (newKey === '__proto__' || newKey === 'constructor' || newKey === 'prototype') {
+        setValidationError(localize('com_config_server_name_invalid'));
+        return;
+      }
+      if (Object.hasOwn(record, newKey)) {
+        setValidationError(localize('com_config_server_name_exists'));
+        return;
+      }
+      const oldPrefixFull = `${path}.${oldKey}`;
+      if (editedValues) {
+        for (const editPath of Object.keys(editedValues)) {
+          if (editPath === oldPrefixFull || editPath.startsWith(`${oldPrefixFull}.`)) {
+            onChange(editPath, undefined);
+          }
+        }
+      }
+      const oldPrefix = `${path}.${oldKey}.`;
+      const newPrefix = `${path}.${newKey}.`;
+      const baseEntry = baseRecord[oldKey];
+      const overlayEntry = record[oldKey];
 
-  const handleEntryChange = useCallback(
-    (key: string, newValue: t.ConfigValue) => {
-      onChange(path, { ...record, [key]: newValue });
+      /**
+       * Enumerate leaves recursively so nested per-leaf data like
+       * `headers.Authorization` survives the rename intact. The overlay
+       * representation is authoritative because the edit overlay already
+       * reflects in-flight changes (including deletions); we still walk the
+       * base to find leaves removed only in the overlay so the old paths get
+       * proper undefined-cleanup writes.
+       */
+      const baseLeaves = isPlainObject(baseEntry) ? enumerateLeafPaths(baseEntry) : [];
+      const overlayLeaves = isPlainObject(overlayEntry) ? enumerateLeafPaths(overlayEntry) : [];
+
+      const overlayBySeg = new Map<string, t.ConfigValue>();
+      for (const { segments, value } of overlayLeaves) {
+        overlayBySeg.set(segments.join('.'), value);
+      }
+      const allSegKeys = new Set<string>([
+        ...overlayBySeg.keys(),
+        ...baseLeaves.map((l) => l.segments.join('.')),
+      ]);
+
+      for (const segKey of allSegKeys) {
+        const segments = segKey.split('.');
+        const leafValue = overlayBySeg.get(segKey);
+        if (leafValue !== undefined) {
+          onChange(`${newPrefix}${segments.join('.')}`, leafValue);
+        }
+        onChange(`${oldPrefix}${segments.join('.')}`, undefined);
+      }
+      /**
+       * Emit an entry-path delete on the old key so MongoDB's $unset collapses
+       * the whole subtree. Without this, per-leaf unsets leave an empty parent
+       * object that refetches as a phantom entry under the old name.
+       */
+      onChange(`${path}.${oldKey}`, undefined);
+      setValidationError(null);
     },
-    [record, onChange, path],
+    [onChange, path, localize],
   );
 
   return (
@@ -683,37 +972,34 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           <span>{localize('com_config_create_mcp_server')}</span>
         </button>
       </div>
-      {entries.map(([key, entryValue]) => {
-        // Normalize type for card summary display: resolve http alias and infer
-        // omitted type so the collapsed card shows the effective transport.
-        const entryObj =
-          entryValue && typeof entryValue === 'object' && !Array.isArray(entryValue)
-            ? (entryValue as Record<string, t.ConfigValue>)
-            : {};
-        const rawType = typeof entryObj.type === 'string' ? entryObj.type : '';
-        const effectiveType =
-          (rawType || inferTransportType(entryObj)) === 'http'
-            ? 'streamable-http'
-            : rawType || inferTransportType(entryObj);
-        const displayValue =
-          effectiveType !== rawType ? { ...entryObj, type: effectiveType } : entryValue;
-
-        return (
-          <ObjectEntryCard
-            key={key}
-            id={`section-mcpServers-${encodeURIComponent(key)}`}
-            entryKey={key}
-            fields={fields}
-            value={displayValue}
-            onValueChange={(v) => handleEntryChange(key, v)}
-            onRemove={disabled ? undefined : () => handleRemove(key)}
-            onRename={disabled ? undefined : (renamed) => handleRename(key, renamed)}
-            disabled={disabled}
-            defaultExpanded={key === justAddedKey}
-            renderFields={renderGroupedMcpFields}
-          />
-        );
-      })}
+      {validationError && (
+        <div className="flex items-center justify-between rounded border border-(--cui-color-stroke-danger) bg-(--cui-color-background-danger-soft) px-3 py-2 text-sm text-(--cui-color-text-danger)">
+          <span>{validationError}</span>
+          <button
+            type="button"
+            onClick={() => setValidationError(null)}
+            className="ml-2 cursor-pointer border-none bg-transparent text-(--cui-color-text-danger) hover:underline"
+            aria-label={localize('com_ui_dismiss')}
+          >
+            ×
+          </button>
+        </div>
+      )}
+      {entries.map(([key, entryValue]) => (
+        <McpEntryRow
+          key={key}
+          entryKey={key}
+          entryValue={entryValue}
+          fields={fields}
+          path={path}
+          disabled={disabled}
+          isYamlSource={yamlSourceKeys.has(key)}
+          onChange={onChange}
+          onRemove={handleRemove}
+          onRename={handleRename}
+          justAddedKey={justAddedKey}
+        />
+      ))}
       {entries.length === 0 && (
         <p className="py-2 text-sm text-(--cui-color-text-muted)">
           {localize('com_config_no_entries')}
@@ -725,8 +1011,119 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         onSave={handleCreate}
         fields={fields}
         existingKeys={existingKeys}
-        renderFields={renderGroupedMcpFields}
+        renderFields={(entryFields, ev, ep, eoc) => (
+          <McpEntryFields
+            fields={entryFields}
+            parentValue={ev}
+            parentPath={ep}
+            onChange={eoc}
+            disabled={disabled}
+          />
+        )}
       />
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// McpEntryRow — single entry card, memoized per entry
+// ---------------------------------------------------------------------------
+
+const McpEntryRow = memo(function McpEntryRowImpl({
+  entryKey,
+  entryValue,
+  fields,
+  path,
+  disabled,
+  isYamlSource,
+  onChange,
+  onRemove,
+  onRename,
+  justAddedKey,
+}: {
+  entryKey: string;
+  entryValue: t.ConfigValue;
+  fields: t.SchemaField[];
+  path: string;
+  disabled?: boolean;
+  isYamlSource: boolean;
+  onChange: (path: string, value: t.ConfigValue) => void;
+  onRemove: (key: string) => void;
+  onRename: (oldKey: string, newKey: string) => void;
+  justAddedKey: string | null;
+}) {
+  const entryObj = isPlainObject(entryValue) ? entryValue : {};
+  const rawType = typeof entryObj.type === 'string' ? entryObj.type : '';
+  const inferred = rawType || inferTransportType(entryObj);
+  const effectiveType = inferred === 'http' ? 'streamable-http' : inferred;
+  const displayValue =
+    effectiveType !== rawType ? { ...entryObj, type: effectiveType } : entryValue;
+
+  const entryPathBase = `${path}.${entryKey}`;
+  const lockedKeys = isYamlSource ? YAML_LOCKED_FIELDS : undefined;
+
+  /**
+   * Stable per-leaf onChange shared across renderFields invocations. Hoisting
+   * this out of the renderEntryFields closure keeps child component identity
+   * steady when the parent re-renders with the same props.
+   */
+  const entryOnChange = useCallback(
+    (leafKey: string, leafValue: t.ConfigValue) => {
+      onChange(`${entryPathBase}.${leafKey}`, leafValue);
+    },
+    [onChange, entryPathBase],
+  );
+
+  /**
+   * Bypass ObjectEntryCard.handleFieldChange and write absolute per-leaf paths
+   * directly. The renderFields callback ignores the handleFieldChange supplied
+   * by ObjectEntryCard and uses an entry-scoped onChange built here that
+   * prefixes with the full entry path.
+   */
+  const renderEntryFields: t.CollectionRenderFields = useCallback(
+    (entryFields, ev, ep) => (
+      <McpEntryFields
+        fields={entryFields}
+        parentValue={ev}
+        parentPath={ep}
+        onChange={entryOnChange}
+        disabled={disabled}
+        lockedKeys={lockedKeys}
+      />
+    ),
+    [entryOnChange, disabled, lockedKeys],
+  );
+
+  /** Whole-entry replace path (kept for back-compat with ObjectEntryCard's
+   *  onValueChange contract). Not used by typical leaf edits. */
+  const handleWholeEntryChange = useCallback(
+    (v: t.ConfigValue) => {
+      onChange(entryPathBase, v);
+    },
+    [onChange, entryPathBase],
+  );
+
+  return (
+    <ObjectEntryCard
+      id={`section-mcpServers-${encodeURIComponent(entryKey)}`}
+      entryKey={entryKey}
+      fields={fields}
+      value={displayValue}
+      onValueChange={handleWholeEntryChange}
+      onRemove={disabled || isYamlSource ? undefined : () => onRemove(entryKey)}
+      onRename={disabled || isYamlSource ? undefined : (renamed) => onRename(entryKey, renamed)}
+      disabled={disabled}
+      defaultExpanded={entryKey === justAddedKey}
+      renderFields={renderEntryFields}
+    />
+  );
+});
+
+// Re-export metadata constants used by tests / future schema-driven extraction.
+export {
+  YAML_LOCKED_FIELDS,
+  INSPECTOR_DERIVED,
+  REQUIRED_BY_TRANSPORT,
+  inferTransportType,
+  enumerateLeafPaths,
+};

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -781,6 +781,8 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
 
   const handleRemove = useCallback(
     (key: string) => {
+      /** Dotted entry names cannot survive the per-leaf save path; the row hides the trash button for them, this is defense-in-depth so no programmatic caller can corrupt sibling subtrees by emitting `mcpServers.<dotted>.<...>` writes. */
+      if (key.includes('.')) return;
       const editedValues = editedValuesRef.current;
       const baseRecord = baseRecordRef.current;
       const prefix = `${path}.${key}.`;
@@ -814,6 +816,8 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
       if (newKey === oldKey) {
         return;
       }
+      /** Same dotted-key reasoning as handleRemove; defense-in-depth even though the row hides the rename pencil. */
+      if (oldKey.includes('.')) return;
       const editedValues = editedValuesRef.current;
       const baseRecord = baseRecordRef.current;
       const record = recordRef.current;
@@ -953,13 +957,18 @@ const McpEntryRow = memo(function McpEntryRowImpl({
     effectiveType !== rawType ? { ...entryObj, type: effectiveType } : entryValue;
 
   const entryPathBase = `${path}.${entryKey}`;
-  const lockedKeys = isYamlSource ? YAML_LOCKED_FIELDS : undefined;
+  /** Dotted entry names predate the dot-rejecting create/rename validators; the save endpoint parses fieldPath as dot-delimited so any per-leaf write under such a key collides with a parallel "legacy" → "dotted" nested-object interpretation. Render them read-only so they stay visible in the list but never round-trip through the per-field save API. */
+  const isDottedLegacy = entryKey.includes('.');
+  const isReadOnly = !!disabled || isDottedLegacy;
+  const isLockedIdentity = isYamlSource || isDottedLegacy;
+  const lockedKeys = isYamlSource && !isDottedLegacy ? YAML_LOCKED_FIELDS : undefined;
 
   const entryOnChange = useCallback(
     (leafKey: string, leafValue: t.ConfigValue) => {
+      if (isDottedLegacy) return;
       onChange(`${entryPathBase}.${leafKey}`, leafValue);
     },
-    [onChange, entryPathBase],
+    [onChange, entryPathBase, isDottedLegacy],
   );
 
   const renderEntryFields: t.CollectionRenderFields = useCallback(
@@ -969,19 +978,20 @@ const McpEntryRow = memo(function McpEntryRowImpl({
         parentValue={ev}
         parentPath={ep}
         onChange={entryOnChange}
-        disabled={disabled}
+        disabled={isReadOnly}
         lockedKeys={lockedKeys}
       />
     ),
-    [entryOnChange, disabled, lockedKeys],
+    [entryOnChange, isReadOnly, lockedKeys],
   );
 
   /** Required by ObjectEntryCard's onValueChange contract; unused on leaf edits. */
   const handleWholeEntryChange = useCallback(
     (v: t.ConfigValue) => {
+      if (isDottedLegacy) return;
       onChange(entryPathBase, v);
     },
-    [onChange, entryPathBase],
+    [onChange, entryPathBase, isDottedLegacy],
   );
 
   return (
@@ -991,9 +1001,9 @@ const McpEntryRow = memo(function McpEntryRowImpl({
       fields={fields}
       value={displayValue}
       onValueChange={handleWholeEntryChange}
-      onRemove={disabled || isYamlSource ? undefined : () => onRemove(entryKey)}
-      onRename={disabled || isYamlSource ? undefined : (renamed) => onRename(entryKey, renamed)}
-      disabled={disabled}
+      onRemove={isReadOnly || isLockedIdentity ? undefined : () => onRemove(entryKey)}
+      onRename={isReadOnly || isLockedIdentity ? undefined : (renamed) => onRename(entryKey, renamed)}
+      disabled={isReadOnly}
       defaultExpanded={entryKey === justAddedKey}
       renderFields={renderEntryFields}
     />

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -697,11 +697,11 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     disabled,
     editedValues,
     yamlBaseKeys,
+    onValidationError,
   } = props;
   const localize = useLocalize();
   const [createOpen, setCreateOpen] = useState(false);
   const [justAddedKey, setJustAddedKey] = useState<string | null>(null);
-  const [validationError, setValidationError] = useState<string | null>(null);
 
   const path = parentPath;
   const entryPrefix = `${path}.`;
@@ -821,7 +821,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
   const handleCreate = useCallback(
     (serverName: string, entry: Record<string, t.ConfigValue>) => {
       if (serverName.includes('.')) {
-        setValidationError(localize('com_config_server_name_no_dots'));
+        onValidationError?.(localize('com_config_server_name_no_dots'));
         return;
       }
       if (
@@ -829,7 +829,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         serverName === 'constructor' ||
         serverName === 'prototype'
       ) {
-        setValidationError(localize('com_config_server_name_invalid'));
+        onValidationError?.(localize('com_config_server_name_invalid'));
         return;
       }
       for (const [fieldKey, fieldValue] of Object.entries(entry)) {
@@ -846,10 +846,9 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           onChange(`${path}.${serverName}.${fieldKey}`, fieldValue);
         }
       }
-      setValidationError(null);
       setJustAddedKey(serverName);
     },
-    [onChange, path, localize],
+    [onChange, path, localize, onValidationError],
   );
 
   const handleRemove = useCallback(
@@ -889,22 +888,21 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
   const handleRename = useCallback(
     (oldKey: string, newKey: string) => {
       if (newKey === oldKey) {
-        setValidationError(null);
         return;
       }
       const editedValues = editedValuesRef.current;
       const baseRecord = baseRecordRef.current;
       const record = recordRef.current;
       if (newKey.includes('.')) {
-        setValidationError(localize('com_config_server_name_no_dots'));
+        onValidationError?.(localize('com_config_server_name_no_dots'));
         return;
       }
       if (newKey === '__proto__' || newKey === 'constructor' || newKey === 'prototype') {
-        setValidationError(localize('com_config_server_name_invalid'));
+        onValidationError?.(localize('com_config_server_name_invalid'));
         return;
       }
       if (Object.hasOwn(record, newKey)) {
-        setValidationError(localize('com_config_server_name_exists'));
+        onValidationError?.(localize('com_config_server_name_exists'));
         return;
       }
       const oldPrefixFull = `${path}.${oldKey}`;
@@ -954,9 +952,8 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
        * object that refetches as a phantom entry under the old name.
        */
       onChange(`${path}.${oldKey}`, undefined);
-      setValidationError(null);
     },
-    [onChange, path, localize],
+    [onChange, path, localize, onValidationError],
   );
 
   return (
@@ -972,19 +969,6 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           <span>{localize('com_config_create_mcp_server')}</span>
         </button>
       </div>
-      {validationError && (
-        <div className="flex items-center justify-between rounded border border-(--cui-color-stroke-danger) bg-(--cui-color-background-danger-soft) px-3 py-2 text-sm text-(--cui-color-text-danger)">
-          <span>{validationError}</span>
-          <button
-            type="button"
-            onClick={() => setValidationError(null)}
-            className="ml-2 cursor-pointer border-none bg-transparent text-(--cui-color-text-danger) hover:underline"
-            aria-label={localize('com_ui_dismiss')}
-          >
-            ×
-          </button>
-        </div>
-      )}
       {entries.map(([key, entryValue]) => (
         <McpEntryRow
           key={key}

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -754,10 +754,21 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     recordRef.current = record;
   }, [record]);
 
+  /** ConfigPage passes a fresh inline arrow each render for onValidationError, and useLocalize returns a new function reference each render too; without these refs the create/rename callbacks below would change identity every render and defeat the memo on McpEntryRow. */
+  const onValidationErrorRef = useRef(onValidationError);
+  useEffect(() => {
+    onValidationErrorRef.current = onValidationError;
+  }, [onValidationError]);
+
+  const localizeRef = useRef(localize);
+  useEffect(() => {
+    localizeRef.current = localize;
+  }, [localize]);
+
   const handleCreate = useCallback(
     (serverName: string, entry: Record<string, t.ConfigValue>) => {
       if (serverName.includes('.')) {
-        onValidationError?.(localize('com_config_server_name_no_dots'));
+        onValidationErrorRef.current?.(localizeRef.current('com_config_server_name_no_dots'));
         return;
       }
       if (
@@ -765,7 +776,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         serverName === 'constructor' ||
         serverName === 'prototype'
       ) {
-        onValidationError?.(localize('com_config_server_name_invalid'));
+        onValidationErrorRef.current?.(localizeRef.current('com_config_server_name_invalid'));
         return;
       }
       for (const [fieldKey, fieldValue] of Object.entries(entry)) {
@@ -784,7 +795,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
       }
       setJustAddedKey(serverName);
     },
-    [onChange, path, localize, onValidationError],
+    [onChange, path],
   );
 
   const handleRemove = useCallback(
@@ -830,15 +841,15 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
       const baseRecord = baseRecordRef.current;
       const record = recordRef.current;
       if (newKey.includes('.')) {
-        onValidationError?.(localize('com_config_server_name_no_dots'));
+        onValidationErrorRef.current?.(localizeRef.current('com_config_server_name_no_dots'));
         return;
       }
       if (newKey === '__proto__' || newKey === 'constructor' || newKey === 'prototype') {
-        onValidationError?.(localize('com_config_server_name_invalid'));
+        onValidationErrorRef.current?.(localizeRef.current('com_config_server_name_invalid'));
         return;
       }
       if (Object.hasOwn(record, newKey)) {
-        onValidationError?.(localize('com_config_server_name_exists'));
+        onValidationErrorRef.current?.(localizeRef.current('com_config_server_name_exists'));
         return;
       }
       const oldPrefixFull = `${path}.${oldKey}`;
@@ -878,7 +889,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
       /** See $unset note in handleRemove. */
       onChange(`${path}.${oldKey}`, undefined);
     },
-    [onChange, path, localize, onValidationError],
+    [onChange, path],
   );
 
   return (

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -1,17 +1,3 @@
-/**
- * Custom section renderer for `mcpServers` — the MCP Servers tab.
- *
- * Renders MCP server entries as expandable cards with:
- *  - Transport-type-aware field visibility (stdio vs sse vs streamable-http vs websocket)
- *  - Semantic field groups (Connection, Authentication, Server Options, Advanced)
- *  - A "Create MCP Server" dialog for adding new entries
- *  - TOC-compatible scroll targets via entry card IDs
- *
- * All edits write per-leaf paths (`mcpServers.<key>.<field>`) into editedValues
- * so single-field reset, baseline-equality dirty pruning, and rename orphan
- * cleanup all work uniformly.
- */
-
 import { Icon } from '@clickhouse/click-ui';
 import { memo, useRef, useMemo, useState, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
@@ -26,11 +12,6 @@ import { FormDialog } from '@/components/shared';
 import { useLocalize } from '@/hooks';
 import { cn } from '@/utils';
 
-// ---------------------------------------------------------------------------
-// Transport type → field visibility
-// ---------------------------------------------------------------------------
-
-/** Fields specific to each transport type. */
 const TRANSPORT_FIELDS: Record<string, string[]> = {
   stdio: ['command', 'args', 'env', 'stderr'],
   sse: ['url', 'headers'],
@@ -39,15 +20,10 @@ const TRANSPORT_FIELDS: Record<string, string[]> = {
   websocket: ['url'],
 };
 
-/** All transport-specific field keys (union of all TRANSPORT_FIELDS values). */
 const ALL_TRANSPORT_KEYS = new Set(Object.values(TRANSPORT_FIELDS).flat());
-
-/** Auth-related fields only shown for remote transports (not stdio). */
 const REMOTE_ONLY_FIELDS = new Set(['requiresOAuth', 'apiKey', 'oauth', 'oauth_headers']);
-
 const REMOTE_TRANSPORTS = new Set(['sse', 'streamable-http', 'http', 'websocket']);
 
-/** Fields that require a value depending on transport type. */
 const REQUIRED_BY_TRANSPORT: Record<string, Set<string>> = {
   stdio: new Set(['command', 'args']),
   sse: new Set(['url']),
@@ -56,7 +32,6 @@ const REQUIRED_BY_TRANSPORT: Record<string, Set<string>> = {
   websocket: new Set(['url']),
 };
 
-/** Curated transport type options with lowercase labels, excluding `http` alias. */
 const TRANSPORT_TYPE_OPTIONS: { label: string; value: string }[] = [
   { label: 'streamable-http', value: 'streamable-http' },
   { label: 'sse', value: 'sse' },
@@ -64,17 +39,12 @@ const TRANSPORT_TYPE_OPTIONS: { label: string; value: string }[] = [
   { label: 'websocket', value: 'websocket' },
 ];
 
-/** The `type` field is always required. */
 const ALWAYS_REQUIRED = new Set(['type']);
 
 /**
- * Infer transport type from configured fields, mirroring Zod's union resolution
- * order in MCPOptionsSchema: Stdio → WebSocket → SSE → StreamableHTTP.
- *
  * YAML configs can omit `type` because each transport schema (except
- * streamable-http) provides a default. The backend infers the type from the
- * discriminating fields (command, url protocol). We replicate that here so the
- * UI shows the effective type for existing configs.
+ * streamable-http) defaults from the discriminating fields. Mirror the
+ * backend's Zod union resolution order so the UI shows the effective type.
  */
 function inferTransportType(values: Record<string, t.ConfigValue>): string {
   if (typeof values.type === 'string' && values.type) return values.type;
@@ -84,7 +54,7 @@ function inferTransportType(values: Record<string, t.ConfigValue>): string {
       const protocol = new URL(values.url).protocol;
       if (protocol === 'ws:' || protocol === 'wss:') return 'websocket';
     } catch {
-      // invalid URL — fall through to sse as default for any url presence
+      /* fall through */
     }
     return 'sse';
   }
@@ -101,10 +71,6 @@ function withFieldOverrides(field: t.SchemaField, transportType: string): t.Sche
   }
   return field;
 }
-
-// ---------------------------------------------------------------------------
-// Per-leaf edit overlay helpers
-// ---------------------------------------------------------------------------
 
 function setLeaf(
   target: Record<string, t.ConfigValue>,
@@ -157,12 +123,6 @@ function isPlainObject(value: t.ConfigValue): value is Record<string, t.ConfigVa
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-/**
- * Walks a nested record and returns one entry per leaf (primitive or array).
- * Used by rename to enumerate every leaf path beneath an MCP entry so nested
- * structures like `headers.Authorization` survive the rename intact instead of
- * collapsing into one whole-object write.
- */
 function enumerateLeafPaths(
   obj: Record<string, t.ConfigValue>,
   prefix: string[] = [],
@@ -182,15 +142,10 @@ function enumerateLeafPaths(
   return out;
 }
 
-// ---------------------------------------------------------------------------
-// Semantic field groups
-// ---------------------------------------------------------------------------
-
 interface FieldGroupDef {
   labelKey: string;
   fields: string[];
   defaultExpanded: boolean;
-  /** Nested sub-groups rendered inside this group (fields should be empty when using children). */
   children?: FieldGroupDef[];
 }
 
@@ -234,10 +189,6 @@ const MCP_FIELD_GROUPS: FieldGroupDef[] = [
   },
 ];
 
-// ---------------------------------------------------------------------------
-// FieldGroup — collapsible group within a card (replicates EndpointsRenderer)
-// ---------------------------------------------------------------------------
-
 function flattenGroupFields(
   fields: t.SchemaField[],
   parentValue: t.ConfigValue,
@@ -254,9 +205,6 @@ function flattenGroupFields(
   const nodes: ReactNode[] = [];
   for (const field of fields) {
     const fieldDisabled = disabled || (lockedKeys?.has(field.key) ?? false);
-    // Custom render for transport type select — curated options with lowercase labels.
-    // When `type` is omitted (common in YAML configs), infer it from other fields
-    // to mirror backend Zod union resolution.
     if (field.key === 'type') {
       const fieldId = `${parentPath}-${field.key}`;
       const label = localize(`com_config_field_${field.key}`);
@@ -324,7 +272,6 @@ function flattenGroupFields(
   return nodes;
 }
 
-/** Parent-level collapsible section that wraps child sub-groups. */
 function FieldGroupSection({
   labelKey,
   defaultExpanded,
@@ -441,10 +388,6 @@ function FieldGroup({
   );
 }
 
-// ---------------------------------------------------------------------------
-// McpEntryFields — dynamic visibility based on transport type
-// ---------------------------------------------------------------------------
-
 function McpEntryFields({
   fields,
   parentValue,
@@ -465,7 +408,6 @@ function McpEntryFields({
   const explicitType = typeof values.type === 'string' ? values.type : '';
   const currentType = explicitType || inferTransportType(values);
 
-  // Build visible field keys based on current transport type
   const currentTransportFields = new Set(TRANSPORT_FIELDS[currentType] ?? []);
   const isRemote = REMOTE_TRANSPORTS.has(currentType);
   const visibleKeys = new Set<string>();
@@ -577,10 +519,6 @@ function McpEntryFields({
   );
 }
 
-// ---------------------------------------------------------------------------
-// CreateMcpServerDialog
-// ---------------------------------------------------------------------------
-
 function CreateMcpServerDialog({
   open,
   onClose,
@@ -683,9 +621,6 @@ function CreateMcpServerDialog({
   );
 }
 
-// ---------------------------------------------------------------------------
-// McpServersRenderer — main export
-// ---------------------------------------------------------------------------
 
 export function McpServersRenderer(props: t.FieldRendererProps) {
   const {
@@ -708,13 +643,6 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
   const baseValue = getValue(path, parentValue ?? {});
   const baseRecord: Record<string, t.ConfigValue> = isPlainObject(baseValue) ? baseValue : {};
 
-  /**
-   * Group edited paths by their entry key. Per-leaf paths are
-   * `mcpServers.<key>.<...>`; the entry key is the first path segment after
-   * the renderer's parent path. We collect [segmentsAfterEntry, value] pairs
-   * keyed by entry name so the record overlay can apply edits per entry
-   * without re-walking the full edit map.
-   */
   const editsByEntry = useMemo(() => {
     const map = new Map<string, Array<{ segments: string[]; value: t.ConfigValue }>>();
     if (!editedValues) return map;
@@ -732,14 +660,6 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     return map;
   }, [editedValues, entryPrefix]);
 
-  /**
-   * Effective record overlay: walks every per-leaf edit for each entry and
-   * applies it on top of the base value. Leaf undefined deletes the leaf;
-   * if every leaf under an entry is undefined and the entry has no remaining
-   * keys, the entry is removed from the rendered list. Entries with no edits
-   * are referenced by identity from `baseRecord` (no deep clone) so steady
-   * state does not pay for cloning unchanged data.
-   */
   const record = useMemo(() => {
     if (editsByEntry.size === 0) return baseRecord;
     const result: Record<string, t.ConfigValue> = {};
@@ -749,8 +669,6 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
       }
     }
     for (const [entryKey, leafEdits] of editsByEntry) {
-      // Whole-entry writes (empty segments) are kept for backward compatibility
-      // with the previous create/delete flows.
       const wholeEntryWrites = leafEdits.filter((e) => e.segments.length === 0);
       const leafWrites = leafEdits.filter((e) => e.segments.length > 0);
 
@@ -784,25 +702,15 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
   const existingKeys = useMemo(() => new Set(Object.keys(record)), [record]);
 
   /**
-   * Server identity is locked iff the entry's name appears in the un-merged
-   * YAML/file base config (sourced via getBaseConfigFn's yamlMcpKeys).
-   *
-   * When the upstream YAML key set is unavailable (older LibreChat backend
-   * without ?baseOnly=true support), return an empty set so nothing is
-   * locked. That degrades to "everything editable" rather than to a
-   * subtraction heuristic which produced false positives on YAML servers
-   * with admin overrides on cosmetic fields like title or iconPath.
+   * Fall back to an empty set when the backend predates ?baseOnly support, so
+   * nothing is locked rather than falling back to a subtraction heuristic that
+   * produces false positives on YAML servers with admin overrides.
    */
   const yamlSourceKeys = useMemo(() => {
     return yamlBaseKeys ?? new Set<string>();
   }, [yamlBaseKeys]);
 
-  /**
-   * Refs let the create/remove/rename callbacks stay referentially stable so
-   * memo(McpEntryRow) actually bails on entries that didn't change. The refs
-   * shadow editedValues/baseRecord/record (each of which changes on every
-   * keystroke) and are read at call time from inside the callback bodies.
-   */
+  /** Refs keep the callbacks referentially stable so memo(McpEntryRow) can bail. */
   const editedValuesRef = useRef(editedValues);
   useEffect(() => {
     editedValuesRef.current = editedValues;
@@ -873,11 +781,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           if (!seen.has(leafPath)) onChange(leafPath, undefined);
         }
       }
-      /**
-       * Also emit a delete at the entry path so MongoDB's $unset collapses
-       * the whole subtree. Per-leaf $unset alone leaves an empty parent
-       * object that refetches as a phantom server entry.
-       */
+      /** Entry-path delete is needed to make MongoDB's $unset collapse the subtree; per-leaf $unset alone leaves an empty parent that refetches as a phantom entry. */
       if (!seen.has(entryPath)) {
         onChange(entryPath, undefined);
       }
@@ -918,14 +822,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
       const baseEntry = baseRecord[oldKey];
       const overlayEntry = record[oldKey];
 
-      /**
-       * Enumerate leaves recursively so nested per-leaf data like
-       * `headers.Authorization` survives the rename intact. The overlay
-       * representation is authoritative because the edit overlay already
-       * reflects in-flight changes (including deletions); we still walk the
-       * base to find leaves removed only in the overlay so the old paths get
-       * proper undefined-cleanup writes.
-       */
+      /** Walk overlay AND base: overlay holds in-flight edits, base catches leaves the overlay has already deleted so their old paths still get undefined-cleanup writes. */
       const baseLeaves = isPlainObject(baseEntry) ? enumerateLeafPaths(baseEntry) : [];
       const overlayLeaves = isPlainObject(overlayEntry) ? enumerateLeafPaths(overlayEntry) : [];
 
@@ -946,11 +843,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
         }
         onChange(`${oldPrefix}${segments.join('.')}`, undefined);
       }
-      /**
-       * Emit an entry-path delete on the old key so MongoDB's $unset collapses
-       * the whole subtree. Without this, per-leaf unsets leave an empty parent
-       * object that refetches as a phantom entry under the old name.
-       */
+      /** See $unset note in handleRemove. */
       onChange(`${path}.${oldKey}`, undefined);
     },
     [onChange, path, localize, onValidationError],
@@ -1009,10 +902,6 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// McpEntryRow — single entry card, memoized per entry
-// ---------------------------------------------------------------------------
-
 const McpEntryRow = memo(function McpEntryRowImpl({
   entryKey,
   entryValue,
@@ -1046,11 +935,6 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   const entryPathBase = `${path}.${entryKey}`;
   const lockedKeys = isYamlSource ? YAML_LOCKED_FIELDS : undefined;
 
-  /**
-   * Stable per-leaf onChange shared across renderFields invocations. Hoisting
-   * this out of the renderEntryFields closure keeps child component identity
-   * steady when the parent re-renders with the same props.
-   */
   const entryOnChange = useCallback(
     (leafKey: string, leafValue: t.ConfigValue) => {
       onChange(`${entryPathBase}.${leafKey}`, leafValue);
@@ -1058,12 +942,6 @@ const McpEntryRow = memo(function McpEntryRowImpl({
     [onChange, entryPathBase],
   );
 
-  /**
-   * Bypass ObjectEntryCard.handleFieldChange and write absolute per-leaf paths
-   * directly. The renderFields callback ignores the handleFieldChange supplied
-   * by ObjectEntryCard and uses an entry-scoped onChange built here that
-   * prefixes with the full entry path.
-   */
   const renderEntryFields: t.CollectionRenderFields = useCallback(
     (entryFields, ev, ep) => (
       <McpEntryFields
@@ -1078,8 +956,7 @@ const McpEntryRow = memo(function McpEntryRowImpl({
     [entryOnChange, disabled, lockedKeys],
   );
 
-  /** Whole-entry replace path (kept for back-compat with ObjectEntryCard's
-   *  onValueChange contract). Not used by typical leaf edits. */
+  /** Required by ObjectEntryCard's onValueChange contract; unused on leaf edits. */
   const handleWholeEntryChange = useCallback(
     (v: t.ConfigValue) => {
       onChange(entryPathBase, v);
@@ -1103,7 +980,6 @@ const McpEntryRow = memo(function McpEntryRowImpl({
   );
 });
 
-// Re-export metadata constants used by tests / future schema-driven extraction.
 export {
   YAML_LOCKED_FIELDS,
   INSPECTOR_DERIVED,

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -366,6 +366,50 @@ describe('McpServersRenderer — rejects dotted server names', () => {
   });
 });
 
+describe('McpServersRenderer — entry order', () => {
+  it('keeps an edited entry in its original position instead of moving it to the bottom', () => {
+    const baseRecord = {
+      alpha: { type: 'sse', url: 'https://a.example.com' },
+      beta: { type: 'sse', url: 'https://b.example.com' },
+      gamma: { type: 'sse', url: 'https://c.example.com' },
+    };
+    const editedValues = { 'mcpServers.alpha.url': 'https://a-new.example.com' };
+    const { container } = renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+    });
+
+    const headers = container.querySelectorAll('[data-section-id^="section-mcpServers-"]');
+    const renderedKeys = Array.from(headers).map((h) =>
+      decodeURIComponent((h.getAttribute('data-section-id') ?? '').replace(/^section-mcpServers-/, '')),
+    );
+    expect(renderedKeys).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('appends a freshly-created entry at the bottom', () => {
+    const baseRecord = {
+      alpha: { type: 'sse', url: 'https://a.example.com' },
+      beta: { type: 'sse', url: 'https://b.example.com' },
+    };
+    const editedValues = {
+      'mcpServers.brandNew.type': 'sse',
+      'mcpServers.brandNew.url': 'https://new.example.com',
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+    });
+
+    const headers = container.querySelectorAll('[data-section-id^="section-mcpServers-"]');
+    const renderedKeys = Array.from(headers).map((h) =>
+      decodeURIComponent((h.getAttribute('data-section-id') ?? '').replace(/^section-mcpServers-/, '')),
+    );
+    expect(renderedKeys).toEqual(['alpha', 'beta', 'brandNew']);
+  });
+});
+
 describe('McpServersRenderer — legacy dotted entry keys', () => {
   it('groups edits under the dotted base key instead of splitting on the first dot', () => {
     const baseRecord = {

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -809,6 +809,41 @@ describe('McpServersRenderer — record overlay', () => {
     expect(urlInput).not.toBeNull();
     expect(urlInput!.value).toBe('https://overlay.example.com');
   });
+
+  it('shows the recreated entry when editedValues holds both a whole-entry delete and subsequent leaf writes', () => {
+    const baseRecord = {
+      kapa: { type: 'sse', url: 'https://old.example.com' },
+    };
+    /** Order matters: the delete write must come before the recreate leaves so resolveEntryValue treats it as delete-then-recreate, not recreate-then-delete. */
+    const editedValues = {
+      'mcpServers.kapa': undefined,
+      'mcpServers.kapa.type': 'sse',
+      'mcpServers.kapa.url': 'https://new.example.com',
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+    });
+    expect(screen.getByText('kapa')).toBeTruthy();
+    fireEvent.click(screen.getByText('kapa'));
+    const urlInput = container.querySelector('input#kapa-url') as HTMLInputElement | null;
+    expect(urlInput).not.toBeNull();
+    expect(urlInput!.value).toBe('https://new.example.com');
+  });
+
+  it('hides the entry when the last whole-entry write is a delete with no subsequent leaf writes', () => {
+    const baseRecord = {
+      kapa: { type: 'sse', url: 'https://old.example.com' },
+    };
+    const editedValues = { 'mcpServers.kapa': undefined };
+    renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+    });
+    expect(screen.queryByText('kapa')).toBeNull();
+  });
 });
 
 describe('McpServersRenderer — handleCreate per-leaf writes', () => {

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -443,6 +443,22 @@ describe('validateMcpCrossField', () => {
     expect(errors[0].missingField).toBe('url');
   });
 
+  it('treats a base-mode leaf reset on a YAML-defined entry as revealing the YAML value when the YAML map is supplied as resetFallback', () => {
+    /** In base mode the admin panel writes to the base config override doc; a DELETE on a field path reveals the underlying YAML value. With the YAML map fed in as resetFallback the validator should see the inherited value and not flag the field as missing. */
+    const baseline = {
+      kapa: { type: 'stdio', command: 'node-overridden', args: ['index.js'] },
+    };
+    const yamlFallback = {
+      kapa: { type: 'stdio', command: 'node', args: ['index.js'] },
+    };
+    const errors = validateMcpCrossField(
+      baseline,
+      [['mcpServers.kapa.command', undefined]],
+      yamlFallback,
+    );
+    expect(errors).toEqual([]);
+  });
+
   it('accepts an empty array for stdio args (the Zod schema requires presence but allows []) without flagging it as missing', () => {
     const baseline = {
       foo: { type: 'stdio', command: 'node', args: ['index.js'] },

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -415,6 +415,36 @@ describe('validateMcpCrossField', () => {
     ]);
     expect(errors).toEqual([]);
   });
+
+  it('treats a scope-mode leaf reset as revealing the inherited base value', () => {
+    /** In scope mode: scopeBaseline has the scope-overridden url; configValues (base) has the inherited url. Resetting mcpServers.foo.url should reveal the base url, so the validator must not flag missing url. */
+    const scopeBaseline = {
+      foo: { type: 'sse', url: 'https://scope-override.example.com' },
+    };
+    const baseFallback = {
+      foo: { type: 'sse', url: 'https://base.example.com' },
+    };
+    const errors = validateMcpCrossField(
+      scopeBaseline,
+      [['mcpServers.foo.url', undefined]],
+      baseFallback,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('still flags a scope reset when no base inheritance is available', () => {
+    const scopeBaseline = {
+      foo: { type: 'sse', url: 'https://scope-only.example.com' },
+    };
+    const baseFallback = {};
+    const errors = validateMcpCrossField(
+      scopeBaseline,
+      [['mcpServers.foo.url', undefined]],
+      baseFallback,
+    );
+    expect(errors.length).toBe(1);
+    expect(errors[0].missingField).toBe('url');
+  });
 });
 
 describe('McpServersRenderer — scope mode', () => {

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -173,6 +173,7 @@ function renderRenderer({
   editedValues = {},
   dbOverridePaths,
   yamlBaseKeys,
+  isEditingScope,
   onChange = vi.fn(),
   onValidationError = vi.fn(),
 }: {
@@ -180,6 +181,7 @@ function renderRenderer({
   editedValues?: t.FlatConfigMap;
   dbOverridePaths?: Set<string>;
   yamlBaseKeys?: Set<string>;
+  isEditingScope?: boolean;
   onChange?: (path: string, value: t.ConfigValue) => void;
   onValidationError?: (message: string) => void;
 }) {
@@ -197,6 +199,7 @@ function renderRenderer({
     editedValues,
     dbOverridePaths,
     yamlBaseKeys,
+    isEditingScope,
     onValidationError,
   };
   return {
@@ -284,6 +287,21 @@ describe('McpServersRenderer — YAML source detection', () => {
     expect(url!.hasAttribute('disabled')).toBe(false);
     expect(container.querySelector('button[aria-label^="com_ui_delete"]')).toBeNull();
     expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).toBeNull();
+  });
+
+  it('allows scoped identity actions on a YAML-defined server', () => {
+    const baseRecord = {
+      kapa: { type: 'sse', url: 'https://example.com', title: 'YAML title' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set(['kapa']),
+      isEditingScope: true,
+    });
+
+    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).not.toBeNull();
+    fireEvent.click(screen.getByText('kapa'));
+    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).not.toBeNull();
   });
 
   it('does not lock identity for a server defined only via admin overrides', () => {

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -448,7 +448,7 @@ describe('validateMcpCrossField', () => {
 });
 
 describe('McpServersRenderer — scope mode', () => {
-  it('disables create and hides rename/delete in scope mode', () => {
+  it('enables create and shows rename/delete affordances in scope mode (tombstone-backed)', () => {
     const baseRecord = {
       adminOnly: { type: 'sse', url: 'https://admin.example.com' },
     };
@@ -460,10 +460,11 @@ describe('McpServersRenderer — scope mode', () => {
 
     const createBtn = screen.getByText('com_config_create_mcp_server')
       .closest('button') as HTMLButtonElement;
-    expect(createBtn.hasAttribute('disabled')).toBe(true);
+    expect(createBtn.hasAttribute('disabled')).toBe(false);
 
-    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).toBeNull();
-    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).toBeNull();
+    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).not.toBeNull();
+    fireEvent.click(screen.getByText('adminOnly'));
+    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).not.toBeNull();
   });
 
   it('still allows field-level edits to flow as per-leaf scope overrides', () => {
@@ -487,6 +488,96 @@ describe('McpServersRenderer — scope mode', () => {
 
     const urlCalls = onChange.mock.calls.filter(([p]) => p === 'mcpServers.adminOnly.url');
     expect(urlCalls.length).toBeGreaterThan(0);
+  });
+
+  it('writes null at entry-path on delete in scope mode (tombstone, not undefined)', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      inherited: { type: 'sse', url: 'https://base.example.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      scopeMode: true,
+      onChange,
+    });
+
+    const deleteBtn = container.querySelector('button[aria-label^="com_ui_delete"]') as HTMLButtonElement | null;
+    expect(deleteBtn).not.toBeNull();
+    fireEvent.click(deleteBtn!);
+
+    const entryWrite = onChange.mock.calls.find(([p]) => p === 'mcpServers.inherited');
+    expect(entryWrite).toBeDefined();
+    expect(entryWrite![1]).toBeNull();
+  });
+
+  it('writes null at old entry-path on rename in scope mode', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      inherited: { type: 'sse', url: 'https://base.example.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      scopeMode: true,
+      onChange,
+    });
+    fireEvent.click(screen.getByText('inherited'));
+    const pencil = container.querySelector(
+      'button[aria-label^="com_a11y_rename_entry"]',
+    ) as HTMLButtonElement | null;
+    expect(pencil).not.toBeNull();
+    fireEvent.click(pencil!);
+    const renameInput = container.querySelector(
+      'input.config-input-ghost',
+    ) as HTMLInputElement | null;
+    expect(renameInput).not.toBeNull();
+    fireEvent.change(renameInput!, { target: { value: 'renamed' } });
+    fireEvent.blur(renameInput!);
+
+    const oldEntryWrite = onChange.mock.calls.find(([p]) => p === 'mcpServers.inherited');
+    expect(oldEntryWrite).toBeDefined();
+    expect(oldEntryWrite![1]).toBeNull();
+    const newLeafWrite = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.renamed.url' && v === 'https://base.example.com',
+    );
+    expect(newLeafWrite).toBeDefined();
+  });
+
+  it('hides an entry from the rendered list when editedValues holds a null tombstone at its entry path', () => {
+    const baseRecord = {
+      inherited: { type: 'sse', url: 'https://base.example.com' },
+      other: { type: 'sse', url: 'https://other.example.com' },
+    };
+    const editedValues = { 'mcpServers.inherited': null as unknown as t.ConfigValue };
+    renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+      scopeMode: true,
+    });
+    expect(screen.queryByText('inherited')).toBeNull();
+    expect(screen.getByText('other')).toBeTruthy();
+  });
+
+  it('writes undefined (not null) at entry-path on delete in base mode', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      adminOnly: { type: 'sse', url: 'https://admin.example.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    const deleteBtn = container.querySelector('button[aria-label^="com_ui_delete"]') as HTMLButtonElement | null;
+    expect(deleteBtn).not.toBeNull();
+    fireEvent.click(deleteBtn!);
+
+    const entryWrite = onChange.mock.calls.find(([p]) => p === 'mcpServers.adminOnly');
+    expect(entryWrite).toBeDefined();
+    expect(entryWrite![1]).toBeUndefined();
   });
 });
 

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -490,10 +490,10 @@ describe('McpServersRenderer — scope mode', () => {
     expect(urlCalls.length).toBeGreaterThan(0);
   });
 
-  it('writes null at entry-path on delete in scope mode (tombstone, not undefined)', () => {
+  it('writes undefined at entry-path on delete in scope mode (the existing DELETE field-path cleanly $unsets a scope-tier entry)', () => {
     const onChange = vi.fn();
     const baseRecord = {
-      inherited: { type: 'sse', url: 'https://base.example.com' },
+      adminOnly: { type: 'sse', url: 'https://admin.example.com' },
     };
     const { container } = renderRenderer({
       baseRecord,
@@ -506,15 +506,15 @@ describe('McpServersRenderer — scope mode', () => {
     expect(deleteBtn).not.toBeNull();
     fireEvent.click(deleteBtn!);
 
-    const entryWrite = onChange.mock.calls.find(([p]) => p === 'mcpServers.inherited');
+    const entryWrite = onChange.mock.calls.find(([p]) => p === 'mcpServers.adminOnly');
     expect(entryWrite).toBeDefined();
-    expect(entryWrite![1]).toBeNull();
+    expect(entryWrite![1]).toBeUndefined();
   });
 
-  it('writes null at old entry-path on rename in scope mode', () => {
+  it('writes undefined at old entry-path on rename in scope mode', () => {
     const onChange = vi.fn();
     const baseRecord = {
-      inherited: { type: 'sse', url: 'https://base.example.com' },
+      adminOnly: { type: 'sse', url: 'https://admin.example.com' },
     };
     const { container } = renderRenderer({
       baseRecord,
@@ -522,7 +522,7 @@ describe('McpServersRenderer — scope mode', () => {
       scopeMode: true,
       onChange,
     });
-    fireEvent.click(screen.getByText('inherited'));
+    fireEvent.click(screen.getByText('adminOnly'));
     const pencil = container.querySelector(
       'button[aria-label^="com_a11y_rename_entry"]',
     ) as HTMLButtonElement | null;
@@ -535,49 +535,13 @@ describe('McpServersRenderer — scope mode', () => {
     fireEvent.change(renameInput!, { target: { value: 'renamed' } });
     fireEvent.blur(renameInput!);
 
-    const oldEntryWrite = onChange.mock.calls.find(([p]) => p === 'mcpServers.inherited');
+    const oldEntryWrite = onChange.mock.calls.find(([p]) => p === 'mcpServers.adminOnly');
     expect(oldEntryWrite).toBeDefined();
-    expect(oldEntryWrite![1]).toBeNull();
+    expect(oldEntryWrite![1]).toBeUndefined();
     const newLeafWrite = onChange.mock.calls.find(
-      ([p, v]) => p === 'mcpServers.renamed.url' && v === 'https://base.example.com',
+      ([p, v]) => p === 'mcpServers.renamed.url' && v === 'https://admin.example.com',
     );
     expect(newLeafWrite).toBeDefined();
-  });
-
-  it('hides an entry from the rendered list when editedValues holds a null tombstone at its entry path', () => {
-    const baseRecord = {
-      inherited: { type: 'sse', url: 'https://base.example.com' },
-      other: { type: 'sse', url: 'https://other.example.com' },
-    };
-    const editedValues = { 'mcpServers.inherited': null as unknown as t.ConfigValue };
-    renderRenderer({
-      baseRecord,
-      editedValues,
-      yamlBaseKeys: new Set<string>(),
-      scopeMode: true,
-    });
-    expect(screen.queryByText('inherited')).toBeNull();
-    expect(screen.getByText('other')).toBeTruthy();
-  });
-
-  it('writes undefined (not null) at entry-path on delete in base mode', () => {
-    const onChange = vi.fn();
-    const baseRecord = {
-      adminOnly: { type: 'sse', url: 'https://admin.example.com' },
-    };
-    const { container } = renderRenderer({
-      baseRecord,
-      yamlBaseKeys: new Set<string>(),
-      onChange,
-    });
-
-    const deleteBtn = container.querySelector('button[aria-label^="com_ui_delete"]') as HTMLButtonElement | null;
-    expect(deleteBtn).not.toBeNull();
-    fireEvent.click(deleteBtn!);
-
-    const entryWrite = onChange.mock.calls.find(([p]) => p === 'mcpServers.adminOnly');
-    expect(entryWrite).toBeDefined();
-    expect(entryWrite![1]).toBeUndefined();
   });
 });
 

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -366,6 +366,55 @@ describe('McpServersRenderer — rejects dotted server names', () => {
   });
 });
 
+describe('McpServersRenderer — legacy dotted entry keys', () => {
+  it('groups edits under the dotted base key instead of splitting on the first dot', () => {
+    const baseRecord = {
+      'legacy.dotted': { type: 'sse', url: 'https://old.example.com' },
+    };
+    const editedValues = { 'mcpServers.legacy.dotted.url': 'https://new.example.com' };
+    const { container } = renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+    });
+
+    const header = screen.queryByText('legacy.dotted');
+    expect(header).not.toBeNull();
+    fireEvent.click(header!);
+    const url = container.querySelector('input#legacy-dotted-url') as HTMLInputElement | null;
+    expect(url).not.toBeNull();
+    expect(url!.value).toBe('https://new.example.com');
+  });
+
+  it('clears the dotted base entry on remove, not a phantom shortened key', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      'legacy.dotted': { type: 'sse', url: 'https://old.example.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    const trashBtn = container.querySelector(
+      'button[aria-label^="com_ui_delete"]',
+    ) as HTMLButtonElement | null;
+    expect(trashBtn).not.toBeNull();
+    fireEvent.click(trashBtn!);
+
+    const undefinedPaths = onChange.mock.calls.filter(([, v]) => v === undefined).map(([p]) => p);
+    expect(undefinedPaths).toEqual(
+      expect.arrayContaining([
+        'mcpServers.legacy.dotted',
+        'mcpServers.legacy.dotted.type',
+        'mcpServers.legacy.dotted.url',
+      ]),
+    );
+    expect(undefinedPaths).not.toContain('mcpServers.legacy');
+  });
+});
+
 describe('McpServersRenderer — handleRemove', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -175,7 +175,6 @@ function renderRenderer({
   yamlBaseKeys,
   onChange = vi.fn(),
   onValidationError = vi.fn(),
-  scopeMode,
 }: {
   baseRecord: Record<string, t.ConfigValue>;
   editedValues?: t.FlatConfigMap;
@@ -183,7 +182,6 @@ function renderRenderer({
   yamlBaseKeys?: Set<string>;
   onChange?: (path: string, value: t.ConfigValue) => void;
   onValidationError?: (message: string) => void;
-  scopeMode?: boolean;
 }) {
   const fields = fieldsForMcp();
   const props: t.FieldRendererProps = {
@@ -200,7 +198,6 @@ function renderRenderer({
     dbOverridePaths,
     yamlBaseKeys,
     onValidationError,
-    scopeMode,
   };
   return {
     ...render(<McpServersRenderer {...props} />),
@@ -445,17 +442,29 @@ describe('validateMcpCrossField', () => {
     expect(errors.length).toBe(1);
     expect(errors[0].missingField).toBe('url');
   });
+
+  it('flags a stdio-by-inference entry whose command is cleared, falling back to the baseline transport when the merged entry loses its discriminator', () => {
+    /** YAML can omit `type` for stdio (the backend Zod schema defaults it). The renderer's transport inference relies on `command` to identify stdio in that case. When the user clears `command`, the merged entry has no discriminator and inferTransportType(entry) returns ''. Without a baseline fallback the validator skipped the required-field check and let the broken entry save. */
+    const baseline = {
+      foo: { command: 'node', args: ['index.js'] },
+    };
+    const errors = validateMcpCrossField(baseline, [
+      ['mcpServers.foo.command', ''],
+    ]);
+    expect(errors.length).toBe(1);
+    expect(errors[0].entryKey).toBe('foo');
+    expect(errors[0].missingField).toBe('command');
+  });
 });
 
-describe('McpServersRenderer — scope mode', () => {
-  it('enables create and shows rename/delete affordances in scope mode (tombstone-backed)', () => {
+describe('McpServersRenderer — non-YAML entry identity affordances', () => {
+  it('enables create and shows rename/delete affordances for a non-YAML entry', () => {
     const baseRecord = {
       adminOnly: { type: 'sse', url: 'https://admin.example.com' },
     };
     const { container } = renderRenderer({
       baseRecord,
       yamlBaseKeys: new Set<string>(),
-      scopeMode: true,
     });
 
     const createBtn = screen.getByText('com_config_create_mcp_server')
@@ -467,7 +476,7 @@ describe('McpServersRenderer — scope mode', () => {
     expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).not.toBeNull();
   });
 
-  it('still allows field-level edits to flow as per-leaf scope overrides', () => {
+  it('flows field-level edits as per-leaf onChange writes', () => {
     const onChange = vi.fn();
     const baseRecord = {
       adminOnly: { type: 'sse', url: 'https://admin.example.com' },
@@ -475,7 +484,6 @@ describe('McpServersRenderer — scope mode', () => {
     const { container } = renderRenderer({
       baseRecord,
       yamlBaseKeys: new Set<string>(),
-      scopeMode: true,
       onChange,
     });
 
@@ -490,7 +498,7 @@ describe('McpServersRenderer — scope mode', () => {
     expect(urlCalls.length).toBeGreaterThan(0);
   });
 
-  it('writes undefined at entry-path on delete in scope mode (the existing DELETE field-path cleanly $unsets a scope-tier entry)', () => {
+  it('writes undefined at the entry path on delete (so the DELETE field-path can $unset the entry cleanly)', () => {
     const onChange = vi.fn();
     const baseRecord = {
       adminOnly: { type: 'sse', url: 'https://admin.example.com' },
@@ -498,7 +506,6 @@ describe('McpServersRenderer — scope mode', () => {
     const { container } = renderRenderer({
       baseRecord,
       yamlBaseKeys: new Set<string>(),
-      scopeMode: true,
       onChange,
     });
 
@@ -511,7 +518,7 @@ describe('McpServersRenderer — scope mode', () => {
     expect(entryWrite![1]).toBeUndefined();
   });
 
-  it('writes undefined at old entry-path on rename in scope mode', () => {
+  it('writes undefined at the old entry path on rename and per-leaf writes for the new key', () => {
     const onChange = vi.fn();
     const baseRecord = {
       adminOnly: { type: 'sse', url: 'https://admin.example.com' },
@@ -519,7 +526,6 @@ describe('McpServersRenderer — scope mode', () => {
     const { container } = renderRenderer({
       baseRecord,
       yamlBaseKeys: new Set<string>(),
-      scopeMode: true,
       onChange,
     });
     fireEvent.click(screen.getByText('adminOnly'));

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -174,6 +174,7 @@ function renderRenderer({
   yamlBaseKeys,
   onChange = vi.fn(),
   onValidationError = vi.fn(),
+  scopeMode,
 }: {
   baseRecord: Record<string, t.ConfigValue>;
   editedValues?: t.FlatConfigMap;
@@ -181,6 +182,7 @@ function renderRenderer({
   yamlBaseKeys?: Set<string>;
   onChange?: (path: string, value: t.ConfigValue) => void;
   onValidationError?: (message: string) => void;
+  scopeMode?: boolean;
 }) {
   const fields = fieldsForMcp();
   const props: t.FieldRendererProps = {
@@ -197,6 +199,7 @@ function renderRenderer({
     dbOverridePaths,
     yamlBaseKeys,
     onValidationError,
+    scopeMode,
   };
   return {
     ...render(<McpServersRenderer {...props} />),
@@ -363,6 +366,49 @@ describe('McpServersRenderer — rejects dotted server names', () => {
       expect.stringContaining('mcpServers.has.dots'),
       expect.anything(),
     );
+  });
+});
+
+describe('McpServersRenderer — scope mode', () => {
+  it('disables create and hides rename/delete in scope mode', () => {
+    const baseRecord = {
+      adminOnly: { type: 'sse', url: 'https://admin.example.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      scopeMode: true,
+    });
+
+    const createBtn = screen.getByText('com_config_create_mcp_server')
+      .closest('button') as HTMLButtonElement;
+    expect(createBtn.hasAttribute('disabled')).toBe(true);
+
+    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).toBeNull();
+    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).toBeNull();
+  });
+
+  it('still allows field-level edits to flow as per-leaf scope overrides', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      adminOnly: { type: 'sse', url: 'https://admin.example.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      scopeMode: true,
+      onChange,
+    });
+
+    fireEvent.click(screen.getByText('adminOnly'));
+    const urlInput = container.querySelector('input#adminOnly-url') as HTMLInputElement | null;
+    expect(urlInput).not.toBeNull();
+    expect(urlInput!.hasAttribute('disabled')).toBe(false);
+    fireEvent.change(urlInput!, { target: { value: 'https://override.example.com' } });
+    fireEvent.blur(urlInput!);
+
+    const urlCalls = onChange.mock.calls.filter(([p]) => p === 'mcpServers.adminOnly.url');
+    expect(urlCalls.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -443,6 +443,16 @@ describe('validateMcpCrossField', () => {
     expect(errors[0].missingField).toBe('url');
   });
 
+  it('accepts an empty array for stdio args (the Zod schema requires presence but allows []) without flagging it as missing', () => {
+    const baseline = {
+      foo: { type: 'stdio', command: 'node', args: ['index.js'] },
+    };
+    const errors = validateMcpCrossField(baseline, [
+      ['mcpServers.foo.args', []],
+    ]);
+    expect(errors).toEqual([]);
+  });
+
   it('flags a stdio-by-inference entry whose command is cleared, falling back to the baseline transport when the merged entry loses its discriminator', () => {
     /** YAML can omit `type` for stdio (the backend Zod schema defaults it). The renderer's transport inference relies on `command` to identify stdio in that case. When the user clears `command`, the merged entry has no discriminator and inferTransportType(entry) returns ''. Without a baseline fallback the validator skipped the required-field check and let the broken entry save. */
     const baseline = {

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -6,6 +6,7 @@ import {
   YAML_LOCKED_FIELDS,
   INSPECTOR_DERIVED,
   enumerateLeafPaths,
+  validateMcpCrossField,
 } from '../McpServersRenderer';
 import { createField } from '@/test/fixtures';
 
@@ -366,6 +367,53 @@ describe('McpServersRenderer — rejects dotted server names', () => {
       expect.stringContaining('mcpServers.has.dots'),
       expect.anything(),
     );
+  });
+});
+
+describe('validateMcpCrossField', () => {
+  it('flags an existing sse entry whose transport is changed to stdio without command/args', () => {
+    const baseline = {
+      foo: { type: 'sse', url: 'https://x.example.com' },
+    };
+    const errors = validateMcpCrossField(baseline, [
+      ['mcpServers.foo.type', 'stdio'],
+    ]);
+    expect(errors.length).toBe(1);
+    expect(errors[0].entryKey).toBe('foo');
+    expect(errors[0].missingField).toBe('command');
+  });
+
+  it('passes when a transport switch is accompanied by the new required fields', () => {
+    const baseline = {
+      foo: { type: 'sse', url: 'https://x.example.com' },
+    };
+    const errors = validateMcpCrossField(baseline, [
+      ['mcpServers.foo.type', 'stdio'],
+      ['mcpServers.foo.command', 'node'],
+      ['mcpServers.foo.args', ['index.js']],
+    ]);
+    expect(errors).toEqual([]);
+  });
+
+  it('treats http as streamable-http and ignores entries with no edits', () => {
+    const baseline = {
+      foo: { type: 'streamable-http', url: 'https://x.example.com' },
+      bar: { type: 'stdio', command: 'node', args: ['x.js'] },
+    };
+    const errors = validateMcpCrossField(baseline, [
+      ['mcpServers.foo.type', 'http'],
+    ]);
+    expect(errors).toEqual([]);
+  });
+
+  it('does not flag a deleted entry', () => {
+    const baseline = {
+      foo: { type: 'sse', url: 'https://x.example.com' },
+    };
+    const errors = validateMcpCrossField(baseline, [
+      ['mcpServers.foo', undefined],
+    ]);
+    expect(errors).toEqual([]);
   });
 });
 

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -1,0 +1,686 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type * as t from '@/types';
+import {
+  McpServersRenderer,
+  YAML_LOCKED_FIELDS,
+  INSPECTOR_DERIVED,
+  enumerateLeafPaths,
+} from '../McpServersRenderer';
+import { createField } from '@/test/fixtures';
+
+vi.mock('@/hooks/useLocalize', () => ({
+  default: () => (key: string) => key,
+  useLocalize: () => (key: string) => key,
+}));
+
+interface IconProps {
+  name: string;
+}
+interface SwitchProps {
+  checked: boolean;
+  onCheckedChange?: (v: boolean) => void;
+  'aria-label'?: string;
+}
+interface SelectProps {
+  children: React.ReactNode;
+  value: string;
+  'aria-label'?: string;
+  onValueChange?: (v: string) => void;
+}
+interface SelectItemProps {
+  children: React.ReactNode;
+  value: string;
+}
+interface ButtonProps {
+  label?: string;
+  onClick?: () => void;
+  children?: React.ReactNode;
+}
+interface TextFieldProps {
+  id?: string;
+  value?: string;
+  placeholder?: string;
+  onChange?: (v: string) => void;
+  onBlur?: () => void;
+  type?: string;
+  disabled?: boolean;
+  'aria-label'?: string;
+}
+interface NumberFieldProps {
+  id?: string;
+  value?: string | number;
+  placeholder?: string;
+  onChange?: (v: string) => void;
+  onBlur?: () => void;
+  disabled?: boolean;
+}
+interface IconButtonProps {
+  icon: string;
+  onClick?: () => void;
+  'aria-label'?: string;
+}
+
+vi.mock('@clickhouse/click-ui', () => ({
+  Icon: ({ name }: IconProps) => <span data-testid={`icon-${name}`} />,
+  Switch: (props: SwitchProps) => (
+    <button
+      role="switch"
+      aria-checked={props.checked}
+      aria-label={props['aria-label']}
+      onClick={() => props.onCheckedChange?.(!props.checked)}
+    />
+  ),
+  Select: Object.assign(
+    ({ children, value, ...props }: SelectProps) => (
+      <div data-testid="select" data-value={value} aria-label={props['aria-label']}>
+        {children}
+      </div>
+    ),
+    {
+      Item: ({ children, value }: SelectItemProps) => (
+        <div data-testid="select-item" data-value={value}>
+          {children}
+        </div>
+      ),
+    },
+  ),
+  Button: ({ label, onClick, children }: ButtonProps) => (
+    <button onClick={onClick}>{label ?? children}</button>
+  ),
+  IconButton: ({ icon, onClick, ...props }: IconButtonProps) => (
+    <button
+      onClick={onClick}
+      aria-label={props['aria-label'] ?? icon}
+      data-testid={`icon-button-${icon}`}
+    />
+  ),
+  TextField: ({
+    id,
+    value,
+    placeholder,
+    onChange,
+    onBlur,
+    type,
+    disabled,
+    ...rest
+  }: TextFieldProps) => (
+    <input
+      id={id}
+      value={value ?? ''}
+      placeholder={placeholder}
+      type={type ?? 'text'}
+      disabled={disabled}
+      aria-label={rest['aria-label']}
+      onChange={(e) => onChange?.(e.target.value)}
+      onBlur={onBlur}
+    />
+  ),
+  NumberField: ({ id, value, placeholder, onChange, onBlur, disabled }: NumberFieldProps) => (
+    <input
+      id={id}
+      value={value ?? ''}
+      placeholder={placeholder}
+      type="number"
+      disabled={disabled}
+      onChange={(e) => onChange?.(e.target.value)}
+      onBlur={onBlur}
+    />
+  ),
+}));
+
+vi.mock('@/components/shared', async () => {
+  const actual = await vi.importActual<typeof import('@/components/shared')>('@/components/shared');
+  return {
+    ...actual,
+    FormDialog: ({
+      open,
+      title,
+      children,
+      onSubmit,
+    }: {
+      open: boolean;
+      title: string;
+      children: React.ReactNode;
+      onSubmit?: () => void;
+    }) =>
+      open ? (
+        <div data-testid="form-dialog" aria-label={title}>
+          {children}
+          <button type="button" onClick={onSubmit}>
+            submit
+          </button>
+        </div>
+      ) : null,
+  };
+});
+
+function fieldsForMcp(): t.SchemaField[] {
+  return [
+    createField({ key: 'type', type: 'enum(stdio | sse | streamable-http | websocket)' }),
+    createField({ key: 'url', type: 'string', isOptional: true }),
+    createField({ key: 'command', type: 'string', isOptional: true }),
+    createField({ key: 'title', type: 'string', isOptional: true }),
+    createField({ key: 'description', type: 'string', isOptional: true }),
+    createField({ key: 'tools', type: 'array<string>', isOptional: true, isArray: true }),
+    createField({ key: 'source', type: 'string', isOptional: true }),
+  ];
+}
+
+function renderRenderer({
+  baseRecord,
+  editedValues = {},
+  dbOverridePaths,
+  yamlBaseKeys,
+  onChange = vi.fn(),
+}: {
+  baseRecord: Record<string, t.ConfigValue>;
+  editedValues?: t.FlatConfigMap;
+  dbOverridePaths?: Set<string>;
+  yamlBaseKeys?: Set<string>;
+  onChange?: (path: string, value: t.ConfigValue) => void;
+}) {
+  const fields = fieldsForMcp();
+  const props: t.FieldRendererProps = {
+    fields,
+    parentValue: baseRecord,
+    parentPath: 'mcpServers',
+    getValue: (path, fallback) => {
+      if (path in editedValues) return editedValues[path] ?? fallback;
+      if (path === 'mcpServers') return baseRecord;
+      return fallback;
+    },
+    onChange,
+    editedValues,
+    dbOverridePaths,
+    yamlBaseKeys,
+  };
+  return { ...render(<McpServersRenderer {...props} />), onChange, fields };
+}
+
+describe('McpServersRenderer — metadata sets', () => {
+  it('locks only the transport-type selector on YAML-defined servers', () => {
+    expect(YAML_LOCKED_FIELDS.has('type')).toBe(true);
+    for (const key of ['url', 'command', 'args', 'env', 'stderr', 'headers']) {
+      expect(YAML_LOCKED_FIELDS.has(key)).toBe(false);
+    }
+  });
+
+  it('hides inspector-derived fields', () => {
+    for (const key of ['tools', 'capabilities', 'source', 'updatedAt']) {
+      expect(INSPECTOR_DERIVED.has(key)).toBe(true);
+    }
+  });
+});
+
+describe('McpServersRenderer — per-leaf write granularity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes per-leaf paths when a single string field changes', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      kapa: { type: 'sse', url: 'https://example.com' },
+    };
+    const { container } = renderRenderer({ baseRecord, onChange });
+
+    fireEvent.click(screen.getByText('kapa'));
+    const urlInput = container.querySelector('input#kapa-url') as HTMLInputElement | null;
+    expect(urlInput).not.toBeNull();
+    fireEvent.change(urlInput!, { target: { value: 'https://new.example.com' } });
+    fireEvent.blur(urlInput!);
+
+    const urlCalls = onChange.mock.calls.filter(([p]) => p === 'mcpServers.kapa.url');
+    expect(urlCalls.length).toBeGreaterThan(0);
+    expect(urlCalls[urlCalls.length - 1][1]).toBe('https://new.example.com');
+    expect(
+      onChange.mock.calls.find(
+        ([p, v]) => p === 'mcpServers.kapa' && typeof v === 'object' && v !== null,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe('McpServersRenderer — YAML source detection', () => {
+  it('keeps transport fields editable on a YAML-defined server with no DB overrides', () => {
+    const baseRecord = {
+      yamlOne: { type: 'stdio', command: 'node', title: 'YAML server' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set(['yamlOne']),
+      dbOverridePaths: new Set(),
+    });
+
+    fireEvent.click(screen.getByText('yamlOne'));
+    const cmd = container.querySelector('input#yamlOne-command') as HTMLInputElement | null;
+    expect(cmd).not.toBeNull();
+    expect(cmd!.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('locks identity (rename/delete) on a YAML-defined server but leaves url editable', () => {
+    const baseRecord = {
+      kapa: { type: 'sse', url: 'https://example.com', title: 'Edited title' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set(['kapa']),
+      dbOverridePaths: new Set(['mcpServers.kapa.title']),
+    });
+
+    fireEvent.click(screen.getByText('kapa'));
+    const url = container.querySelector('input#kapa-url') as HTMLInputElement | null;
+    expect(url).not.toBeNull();
+    expect(url!.hasAttribute('disabled')).toBe(false);
+    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).toBeNull();
+    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).toBeNull();
+  });
+
+  it('does not lock identity for a server defined only via admin overrides', () => {
+    const baseRecord = {
+      adminOnly: { type: 'sse', url: 'https://admin.example.com', title: 'Admin only' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      dbOverridePaths: new Set([
+        'mcpServers.adminOnly.type',
+        'mcpServers.adminOnly.url',
+        'mcpServers.adminOnly.title',
+      ]),
+    });
+
+    fireEvent.click(screen.getByText('adminOnly'));
+    const url = container.querySelector('input#adminOnly-url') as HTMLInputElement | null;
+    expect(url).not.toBeNull();
+    expect(url!.hasAttribute('disabled')).toBe(false);
+    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).not.toBeNull();
+  });
+
+  it('treats a freshly-created entry (not in YAML keys) as fully editable', () => {
+    const baseRecord = {
+      brandNew: { type: 'sse', url: 'https://new.example.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+    });
+
+    fireEvent.click(screen.getByText('brandNew'));
+    const url = container.querySelector('input#brandNew-url') as HTMLInputElement | null;
+    expect(url).not.toBeNull();
+    expect(url!.hasAttribute('disabled')).toBe(false);
+    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).not.toBeNull();
+  });
+});
+
+describe('McpServersRenderer — lock matrix and inspector hide', () => {
+  it('does not render inspector-derived fields like source/tools in the card', () => {
+    const baseRecord = {
+      one: {
+        type: 'sse',
+        url: 'https://x.com',
+        title: 'T',
+        source: 'yaml',
+        tools: ['t1'],
+      },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      dbOverridePaths: new Set(['mcpServers.one.title']),
+    });
+    fireEvent.click(screen.getByText('one'));
+    const sourceInput = container.querySelector('input[id="mcpServers-one-source"]');
+    expect(sourceInput).toBeNull();
+  });
+});
+
+describe('McpServersRenderer — rejects dotted server names', () => {
+  it('shows a no-dots error when create receives a name with a dot', () => {
+    const onChange = vi.fn();
+    const baseRecord = {};
+    renderRenderer({ baseRecord, onChange });
+
+    fireEvent.click(screen.getByText('com_config_create_mcp_server'));
+    const dialog = screen.getByTestId('form-dialog');
+    const nameInput = dialog.querySelector('#mcp-server-name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'has.dots' } });
+    const submit = dialog.querySelector('button[type="button"]') as HTMLButtonElement;
+    fireEvent.click(submit);
+
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.stringContaining('mcpServers.has.dots'),
+      expect.anything(),
+    );
+  });
+});
+
+describe('McpServersRenderer — handleRemove', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits undefined for every leaf path including pending edits and base fields', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      adminOnly: { type: 'sse', url: 'https://admin.example.com' },
+    };
+    const editedValues = { 'mcpServers.adminOnly.title': 'X' };
+    const { container } = renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    const trashBtn = container.querySelector(
+      'button[aria-label^="com_ui_delete"]',
+    ) as HTMLButtonElement | null;
+    expect(trashBtn).not.toBeNull();
+    fireEvent.click(trashBtn!);
+
+    const undefinedPaths = onChange.mock.calls.filter(([, v]) => v === undefined).map(([p]) => p);
+    expect(undefinedPaths).toEqual(
+      expect.arrayContaining([
+        'mcpServers.adminOnly.type',
+        'mcpServers.adminOnly.url',
+        'mcpServers.adminOnly.title',
+      ]),
+    );
+  });
+
+  it('emits an entry-path undefined write so MongoDB unsets the whole subtree', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      foo: { type: 'sse', url: 'https://x.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    const trashBtn = container.querySelector(
+      'button[aria-label^="com_ui_delete"]',
+    ) as HTMLButtonElement | null;
+    expect(trashBtn).not.toBeNull();
+    fireEvent.click(trashBtn!);
+
+    const entryClear = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.foo' && v === undefined,
+    );
+    expect(entryClear).toBeDefined();
+
+    const leafClear = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.foo.type' && v === undefined,
+    );
+    expect(leafClear).toBeDefined();
+  });
+
+  it('recurses into nested base fields so leaves like headers.Authorization clear individually', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      withHeaders: {
+        type: 'sse',
+        url: 'https://x.com',
+        headers: { Authorization: 'Bearer a' },
+      },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    const trashBtn = container.querySelector(
+      'button[aria-label^="com_ui_delete"]',
+    ) as HTMLButtonElement | null;
+    expect(trashBtn).not.toBeNull();
+    fireEvent.click(trashBtn!);
+
+    const authClear = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.withHeaders.headers.Authorization' && v === undefined,
+    );
+    expect(authClear).toBeDefined();
+
+    const wholeHeadersClear = onChange.mock.calls.find(
+      ([p]) => p === 'mcpServers.withHeaders.headers',
+    );
+    expect(wholeHeadersClear).toBeUndefined();
+  });
+});
+
+describe('McpServersRenderer — handleRename', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function triggerRename(container: HTMLElement, newKey: string) {
+    const pencil = container.querySelector(
+      'button[aria-label^="com_a11y_rename_entry"]',
+    ) as HTMLButtonElement | null;
+    expect(pencil).not.toBeNull();
+    fireEvent.click(pencil!);
+    const renameInput = container.querySelector(
+      'input.config-input-ghost',
+    ) as HTMLInputElement | null;
+    expect(renameInput).not.toBeNull();
+    fireEvent.change(renameInput!, { target: { value: newKey } });
+    fireEvent.blur(renameInput!);
+  }
+
+  it('preserves nested per-leaf data when renaming an entry with headers', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      foo: {
+        type: 'sse',
+        url: 'https://x.com',
+        headers: { Authorization: 'Bearer a' },
+      },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    fireEvent.click(screen.getByText('foo'));
+    triggerRename(container, 'bar');
+
+    const newAuth = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.bar.headers.Authorization' && v === 'Bearer a',
+    );
+    expect(newAuth).toBeDefined();
+
+    const oldAuthClear = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.foo.headers.Authorization' && v === undefined,
+    );
+    expect(oldAuthClear).toBeDefined();
+
+    const wholeHeadersWrite = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.bar.headers' && typeof v === 'object' && v !== null,
+    );
+    expect(wholeHeadersWrite).toBeUndefined();
+  });
+
+  it('emits an entry-path undefined write for the old key so MongoDB unsets the whole subtree', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      foo: { type: 'sse', url: 'https://x.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    fireEvent.click(screen.getByText('foo'));
+    triggerRename(container, 'bar');
+
+    const oldEntryClear = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.foo' && v === undefined,
+    );
+    expect(oldEntryClear).toBeDefined();
+
+    const oldLeafClear = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.foo.url' && v === undefined,
+    );
+    expect(oldLeafClear).toBeDefined();
+
+    const newUrlWrite = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.bar.url' && v === 'https://x.com',
+    );
+    expect(newUrlWrite).toBeDefined();
+  });
+
+  it('rejects rename to an existing entry name and surfaces an error banner', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      foo: { type: 'sse', url: 'https://x.com' },
+      bar: { type: 'sse', url: 'https://y.com' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    fireEvent.click(screen.getByText('foo'));
+    triggerRename(container, 'bar');
+
+    const renamePaths = onChange.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.startsWith('mcpServers.bar.'),
+    );
+    expect(renamePaths).toEqual([]);
+    expect(screen.getByText('com_config_server_name_exists')).toBeInTheDocument();
+  });
+});
+
+describe('McpServersRenderer — record overlay', () => {
+  it('applies per-leaf edits over the base record (url visible by default)', () => {
+    const baseRecord = {
+      kapa: { type: 'sse', url: 'https://x.com' },
+    };
+    const editedValues = { 'mcpServers.kapa.url': 'https://overlay.example.com' };
+    const { container } = renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+    });
+    fireEvent.click(screen.getByText('kapa'));
+    const urlInput = container.querySelector('input#kapa-url') as HTMLInputElement | null;
+    expect(urlInput).not.toBeNull();
+    expect(urlInput!.value).toBe('https://overlay.example.com');
+  });
+});
+
+describe('McpServersRenderer — handleCreate per-leaf writes', () => {
+  it('enumerateLeafPaths emits one leaf per primitive even under a nested object', () => {
+    const leaves = enumerateLeafPaths({
+      type: 'sse',
+      url: 'https://example.com',
+      headers: { Authorization: 'Bearer a' },
+    });
+    const flat = leaves.map((l) => ({ path: l.segments.join('.'), value: l.value }));
+    expect(flat).toEqual(
+      expect.arrayContaining([
+        { path: 'type', value: 'sse' },
+        { path: 'url', value: 'https://example.com' },
+        { path: 'headers.Authorization', value: 'Bearer a' },
+      ]),
+    );
+    const headersWhole = flat.find((l) => l.path === 'headers');
+    expect(headersWhole).toBeUndefined();
+  });
+});
+
+describe('McpServersRenderer — rejects reserved server names', () => {
+  it('blocks __proto__ at create without emitting onChange', () => {
+    const onChange = vi.fn();
+    const baseRecord = {};
+    renderRenderer({ baseRecord, onChange });
+
+    fireEvent.click(screen.getByText('com_config_create_mcp_server'));
+    const dialog = screen.getByTestId('form-dialog');
+    const nameInput = dialog.querySelector('#mcp-server-name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: '__proto__' } });
+    const submit = dialog.querySelector('button[type="button"]') as HTMLButtonElement;
+    fireEvent.click(submit);
+
+    const protoCalls = onChange.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.startsWith('mcpServers.__proto__'),
+    );
+    expect(protoCalls).toEqual([]);
+  });
+});
+
+describe('McpServersRenderer — yamlBaseKeys undefined fallback', () => {
+  it('locks nothing when yamlBaseKeys is undefined (newer-UI / older-API)', () => {
+    const baseRecord = {
+      yamlServer: { type: 'sse', url: 'https://x.com', title: 'YAML' },
+    };
+    const { container } = renderRenderer({
+      baseRecord,
+      yamlBaseKeys: undefined,
+      dbOverridePaths: new Set(['mcpServers.yamlServer.title']),
+    });
+
+    fireEvent.click(screen.getByText('yamlServer'));
+    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).not.toBeNull();
+  });
+});
+
+describe('McpServersRenderer — create then edit then rename preserves nested data', () => {
+  it('writes per-leaf paths through edit and rename in sequence', () => {
+    const baseRecord = {
+      kapa: {
+        type: 'sse',
+        url: 'https://x.com',
+        headers: { Authorization: 'old' },
+      },
+    };
+    const editedValues: t.FlatConfigMap = {
+      'mcpServers.kapa.headers.Authorization': 'new',
+    };
+    const onChange = vi.fn();
+    const { container } = renderRenderer({
+      baseRecord,
+      editedValues,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    fireEvent.click(screen.getByText('kapa'));
+    const renameBtn = container.querySelector(
+      'button[aria-label^="com_a11y_rename_entry"]',
+    ) as HTMLButtonElement | null;
+    expect(renameBtn).not.toBeNull();
+    fireEvent.click(renameBtn!);
+    const renameInput = container.querySelector(
+      'input.config-input-ghost',
+    ) as HTMLInputElement | null;
+    expect(renameInput).not.toBeNull();
+    fireEvent.change(renameInput!, { target: { value: 'kapa2' } });
+    fireEvent.blur(renameInput!);
+
+    const authWrite = onChange.mock.calls.find(
+      ([p]) => p === 'mcpServers.kapa2.headers.Authorization',
+    );
+    expect(authWrite).toBeDefined();
+    expect(authWrite![1]).toBe('new');
+
+    const oldClears = onChange.mock.calls.filter(
+      ([p, v]) => typeof p === 'string' && p.startsWith('mcpServers.kapa.') && v === undefined,
+    );
+    expect(oldClears.length).toBeGreaterThan(0);
+
+    const wholeHeadersWrite = onChange.mock.calls.find(
+      ([p, v]) => p === 'mcpServers.kapa2.headers' && typeof v === 'object' && v !== null,
+    );
+    expect(wholeHeadersWrite).toBeUndefined();
+  });
+});

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -173,12 +173,14 @@ function renderRenderer({
   dbOverridePaths,
   yamlBaseKeys,
   onChange = vi.fn(),
+  onValidationError = vi.fn(),
 }: {
   baseRecord: Record<string, t.ConfigValue>;
   editedValues?: t.FlatConfigMap;
   dbOverridePaths?: Set<string>;
   yamlBaseKeys?: Set<string>;
   onChange?: (path: string, value: t.ConfigValue) => void;
+  onValidationError?: (message: string) => void;
 }) {
   const fields = fieldsForMcp();
   const props: t.FieldRendererProps = {
@@ -194,8 +196,14 @@ function renderRenderer({
     editedValues,
     dbOverridePaths,
     yamlBaseKeys,
+    onValidationError,
   };
-  return { ...render(<McpServersRenderer {...props} />), onChange, fields };
+  return {
+    ...render(<McpServersRenderer {...props} />),
+    onChange,
+    onValidationError,
+    fields,
+  };
 }
 
 describe('McpServersRenderer — metadata sets', () => {
@@ -536,8 +544,9 @@ describe('McpServersRenderer — handleRename', () => {
     expect(newUrlWrite).toBeDefined();
   });
 
-  it('rejects rename to an existing entry name and surfaces an error banner', () => {
+  it('rejects rename to an existing entry name and reports a validation error', () => {
     const onChange = vi.fn();
+    const onValidationError = vi.fn();
     const baseRecord = {
       foo: { type: 'sse', url: 'https://x.com' },
       bar: { type: 'sse', url: 'https://y.com' },
@@ -546,6 +555,7 @@ describe('McpServersRenderer — handleRename', () => {
       baseRecord,
       yamlBaseKeys: new Set<string>(),
       onChange,
+      onValidationError,
     });
 
     fireEvent.click(screen.getByText('foo'));
@@ -555,7 +565,7 @@ describe('McpServersRenderer — handleRename', () => {
       ([p]) => typeof p === 'string' && p.startsWith('mcpServers.bar.'),
     );
     expect(renamePaths).toEqual([]);
-    expect(screen.getByText('com_config_server_name_exists')).toBeInTheDocument();
+    expect(onValidationError).toHaveBeenCalledWith('com_config_server_name_exists');
   });
 });
 

--- a/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
+++ b/src/components/configuration/sections/__tests__/McpServersRenderer.test.tsx
@@ -369,12 +369,10 @@ describe('McpServersRenderer — rejects dotted server names', () => {
 describe('McpServersRenderer — legacy dotted entry keys', () => {
   it('groups edits under the dotted base key instead of splitting on the first dot', () => {
     const baseRecord = {
-      'legacy.dotted': { type: 'sse', url: 'https://old.example.com' },
+      'legacy.dotted': { type: 'sse', url: 'https://new.example.com' },
     };
-    const editedValues = { 'mcpServers.legacy.dotted.url': 'https://new.example.com' };
     const { container } = renderRenderer({
       baseRecord,
-      editedValues,
       yamlBaseKeys: new Set<string>(),
     });
 
@@ -386,7 +384,7 @@ describe('McpServersRenderer — legacy dotted entry keys', () => {
     expect(url!.value).toBe('https://new.example.com');
   });
 
-  it('clears the dotted base entry on remove, not a phantom shortened key', () => {
+  it('renders dotted legacy entries read-only with no rename or delete affordances', () => {
     const onChange = vi.fn();
     const baseRecord = {
       'legacy.dotted': { type: 'sse', url: 'https://old.example.com' },
@@ -397,21 +395,30 @@ describe('McpServersRenderer — legacy dotted entry keys', () => {
       onChange,
     });
 
-    const trashBtn = container.querySelector(
-      'button[aria-label^="com_ui_delete"]',
-    ) as HTMLButtonElement | null;
-    expect(trashBtn).not.toBeNull();
-    fireEvent.click(trashBtn!);
+    fireEvent.click(screen.getByText('legacy.dotted'));
+    const url = container.querySelector('input#legacy-dotted-url') as HTMLInputElement | null;
+    expect(url).not.toBeNull();
+    expect(url!.hasAttribute('disabled')).toBe(true);
 
-    const undefinedPaths = onChange.mock.calls.filter(([, v]) => v === undefined).map(([p]) => p);
-    expect(undefinedPaths).toEqual(
-      expect.arrayContaining([
-        'mcpServers.legacy.dotted',
-        'mcpServers.legacy.dotted.type',
-        'mcpServers.legacy.dotted.url',
-      ]),
+    expect(container.querySelector('button[aria-label^="com_ui_delete"]')).toBeNull();
+    expect(container.querySelector('button[aria-label^="com_a11y_rename_entry"]')).toBeNull();
+  });
+
+  it('emits no per-leaf writes for a dotted entry even if the field would otherwise fire onChange', () => {
+    const onChange = vi.fn();
+    const baseRecord = {
+      'legacy.dotted': { type: 'sse', url: 'https://old.example.com' },
+    };
+    renderRenderer({
+      baseRecord,
+      yamlBaseKeys: new Set<string>(),
+      onChange,
+    });
+
+    const dottedWrites = onChange.mock.calls.filter(([p]) =>
+      typeof p === 'string' && p.startsWith('mcpServers.legacy'),
     );
-    expect(undefinedPaths).not.toContain('mcpServers.legacy');
+    expect(dottedWrites).toEqual([]);
   });
 });
 

--- a/src/components/configuration/sections/mcpFieldMeta.ts
+++ b/src/components/configuration/sections/mcpFieldMeta.ts
@@ -1,35 +1,7 @@
-/**
- * Static metadata for MCP server field handling.
- *
- * IMPORTANT: These sets MUST be updated when LibreChat adds new MCP fields.
- * The long-term plan is to encode this information directly in the Zod schema
- * as field-level tags (for example, `meta({ readonly: true })` or
- * `meta({ runtimeOnly: true })`) so the renderer can read it from the schema
- * tree instead of duplicating field-key knowledge. Tracked as future work.
- */
-
-/**
- * Fields on YAML-defined MCP servers that the admin panel cannot edit because
- * mutating them is structurally unsafe under the deployment model.
- *
- * Multi-tenant LibreChat uses YAML for global defaults shared across all
- * tenants; the admin panel is the per-tenant customization surface, so most
- * fields (url, command, args, env, headers, apiKey, oauth) are legitimately
- * tenant-overrideable. Only `type` is locked because changing the transport
- * selector breaks the Zod union (MCPOptionsSchema) and produces
- * inspectionFailed stubs that cannot connect.
- *
- * Server name is locked separately via the hidden onRename affordance, not
- * through this set, because a name change creates a duplicate map key rather
- * than a true rename.
- */
+/** Changing `type` breaks the MCPOptionsSchema Zod union and produces inspectionFailed stubs that cannot connect. */
 export const YAML_LOCKED_FIELDS = new Set(['type']);
 
-/**
- * Fields populated by the MCP inspector at runtime. Admin overrides for these
- * are silently ignored by the inspector, so we hide them from the editor
- * entirely (for both YAML and config-tier servers).
- */
+/** Inspector-populated fields; admin overrides for these are silently ignored. */
 export const INSPECTOR_DERIVED = new Set([
   'tools',
   'capabilities',

--- a/src/components/configuration/sections/mcpFieldMeta.ts
+++ b/src/components/configuration/sections/mcpFieldMeta.ts
@@ -1,0 +1,41 @@
+/**
+ * Static metadata for MCP server field handling.
+ *
+ * IMPORTANT: These sets MUST be updated when LibreChat adds new MCP fields.
+ * The long-term plan is to encode this information directly in the Zod schema
+ * as field-level tags (for example, `meta({ readonly: true })` or
+ * `meta({ runtimeOnly: true })`) so the renderer can read it from the schema
+ * tree instead of duplicating field-key knowledge. Tracked as future work.
+ */
+
+/**
+ * Fields on YAML-defined MCP servers that the admin panel cannot edit because
+ * mutating them is structurally unsafe under the deployment model.
+ *
+ * Multi-tenant LibreChat uses YAML for global defaults shared across all
+ * tenants; the admin panel is the per-tenant customization surface, so most
+ * fields (url, command, args, env, headers, apiKey, oauth) are legitimately
+ * tenant-overrideable. Only `type` is locked because changing the transport
+ * selector breaks the Zod union (MCPOptionsSchema) and produces
+ * inspectionFailed stubs that cannot connect.
+ *
+ * Server name is locked separately via the hidden onRename affordance, not
+ * through this set, because a name change creates a duplicate map key rather
+ * than a true rename.
+ */
+export const YAML_LOCKED_FIELDS = new Set(['type']);
+
+/**
+ * Fields populated by the MCP inspector at runtime. Admin overrides for these
+ * are silently ignored by the inspector, so we hide them from the editor
+ * entirely (for both YAML and config-tier servers).
+ */
+export const INSPECTOR_DERIVED = new Set([
+  'tools',
+  'capabilities',
+  'initDuration',
+  'inspectionFailed',
+  'updatedAt',
+  'dbId',
+  'source',
+]);

--- a/src/components/configuration/utils.test.ts
+++ b/src/components/configuration/utils.test.ts
@@ -4,6 +4,7 @@ import {
   getEnumOptions,
   getArrayItemType,
   splitUnionTypes,
+  partitionScopeResetPaths,
   mergeIndexedArrayEdits,
 } from './utils';
 import { createField } from '@/test/fixtures';
@@ -329,6 +330,35 @@ describe('mergeIndexedArrayEdits', () => {
     ]);
     expect(merged).toEqual({
       endpoints: { custom: { deep: { list: [{ name: 'x' }] } } },
+    });
+  });
+});
+
+describe('partitionScopeResetPaths', () => {
+  it('routes whole MCP entry resets to tombstones', () => {
+    expect(
+      partitionScopeResetPaths([
+        'mcpServers.github',
+        'mcpServers.github.url',
+        'interface.modelSelect',
+      ]),
+    ).toEqual({
+      resetPaths: ['mcpServers.github.url', 'interface.modelSelect'],
+      tombstonePaths: ['mcpServers.github'],
+    });
+  });
+
+  it('preserves input order within reset and tombstone groups', () => {
+    expect(
+      partitionScopeResetPaths([
+        'mcpServers.alpha',
+        'registration.enabled',
+        'mcpServers.beta',
+        'endpoints.custom.0',
+      ]),
+    ).toEqual({
+      resetPaths: ['registration.enabled', 'endpoints.custom.0'],
+      tombstonePaths: ['mcpServers.alpha', 'mcpServers.beta'],
     });
   });
 });

--- a/src/components/configuration/utils.test.ts
+++ b/src/components/configuration/utils.test.ts
@@ -341,10 +341,22 @@ describe('partitionScopeResetPaths', () => {
         'mcpServers.github',
         'mcpServers.github.url',
         'interface.modelSelect',
-      ]),
+      ], new Set(['github'])),
     ).toEqual({
       resetPaths: ['mcpServers.github.url', 'interface.modelSelect'],
       tombstonePaths: ['mcpServers.github'],
+    });
+  });
+
+  it('routes whole MCP entry resets to unsets when the entry is scope-local', () => {
+    expect(
+      partitionScopeResetPaths([
+        'mcpServers.scopeOnly',
+        'mcpServers.inherited',
+      ], new Set(['inherited'])),
+    ).toEqual({
+      resetPaths: ['mcpServers.scopeOnly'],
+      tombstonePaths: ['mcpServers.inherited'],
     });
   });
 
@@ -355,7 +367,7 @@ describe('partitionScopeResetPaths', () => {
         'registration.enabled',
         'mcpServers.beta',
         'endpoints.custom.0',
-      ]),
+      ], new Set(['alpha', 'beta'])),
     ).toEqual({
       resetPaths: ['registration.enabled', 'endpoints.custom.0'],
       tombstonePaths: ['mcpServers.alpha', 'mcpServers.beta'],

--- a/src/components/configuration/utils.ts
+++ b/src/components/configuration/utils.ts
@@ -223,6 +223,28 @@ export function hasDescendant(path: string, paths?: Set<string>): boolean {
   return false;
 }
 
+export function isMcpEntryPath(path: string): boolean {
+  if (!path.startsWith('mcpServers.')) return false;
+  const key = path.slice('mcpServers.'.length);
+  return key.length > 0 && !key.includes('.');
+}
+
+export function partitionScopeResetPaths(paths: string[]): {
+  resetPaths: string[];
+  tombstonePaths: string[];
+} {
+  const resetPaths: string[] = [];
+  const tombstonePaths: string[] = [];
+  for (const path of paths) {
+    if (isMcpEntryPath(path)) {
+      tombstonePaths.push(path);
+    } else {
+      resetPaths.push(path);
+    }
+  }
+  return { resetPaths, tombstonePaths };
+}
+
 /**
  * Merge indexed-array edits (entries whose flat path ends in `.<digit>`) into
  * a config tree. Each indexed edit's value replaces the array element at that

--- a/src/components/configuration/utils.ts
+++ b/src/components/configuration/utils.ts
@@ -229,14 +229,18 @@ export function isMcpEntryPath(path: string): boolean {
   return key.length > 0 && !key.includes('.');
 }
 
-export function partitionScopeResetPaths(paths: string[]): {
+export function partitionScopeResetPaths(
+  paths: string[],
+  inheritedMcpKeys: Set<string>,
+): {
   resetPaths: string[];
   tombstonePaths: string[];
 } {
   const resetPaths: string[] = [];
   const tombstonePaths: string[] = [];
   for (const path of paths) {
-    if (isMcpEntryPath(path)) {
+    const key = path.startsWith('mcpServers.') ? path.slice('mcpServers.'.length) : '';
+    if (isMcpEntryPath(path) && inheritedMcpKeys.has(key)) {
       tombstonePaths.push(path);
     } else {
       resetPaths.push(path);

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -77,6 +77,7 @@
   "com_config_server_name_exists": "A server with this name already exists",
   "com_config_server_name_no_dots": "Server name cannot contain dots",
   "com_config_server_name_invalid": "Server name is not allowed",
+  "com_config_server_missing_required": "Missing required field: {{field}}",
   "com_config_group_connection": "Connection",
   "com_config_group_authentication": "Authentication",
   "com_config_group_api_key": "API key",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -78,7 +78,6 @@
   "com_config_server_name_no_dots": "Server name cannot contain dots",
   "com_config_server_name_invalid": "Server name is not allowed",
   "com_config_server_missing_required": "Missing required field: {{field}}",
-  "com_config_mcp_scope_structural_disabled": "Renaming, creating, and removing MCP servers from a role or group scope is not supported. Make these changes in the base configuration; field-level overrides still work in this scope.",
   "com_config_mcp_invalid_after_edit": "Cannot save: MCP server \"{{entry}}\" is missing required field \"{{field}}\" for its transport type.",
   "com_config_group_connection": "Connection",
   "com_config_group_authentication": "Authentication",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -78,6 +78,7 @@
   "com_config_server_name_no_dots": "Server name cannot contain dots",
   "com_config_server_name_invalid": "Server name is not allowed",
   "com_config_server_missing_required": "Missing required field: {{field}}",
+  "com_config_mcp_scope_structural_disabled": "Renaming, creating, and removing MCP servers from a role or group scope is not supported. Make these changes in the base configuration; field-level overrides still work in this scope.",
   "com_config_group_connection": "Connection",
   "com_config_group_authentication": "Authentication",
   "com_config_group_api_key": "API key",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -75,6 +75,8 @@
   "com_config_server_name": "Server name",
   "com_config_server_name_required": "Server name is required",
   "com_config_server_name_exists": "A server with this name already exists",
+  "com_config_server_name_no_dots": "Server name cannot contain dots",
+  "com_config_server_name_invalid": "Server name is not allowed",
   "com_config_group_connection": "Connection",
   "com_config_group_authentication": "Authentication",
   "com_config_group_api_key": "API key",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -79,6 +79,7 @@
   "com_config_server_name_invalid": "Server name is not allowed",
   "com_config_server_missing_required": "Missing required field: {{field}}",
   "com_config_mcp_scope_structural_disabled": "Renaming, creating, and removing MCP servers from a role or group scope is not supported. Make these changes in the base configuration; field-level overrides still work in this scope.",
+  "com_config_mcp_invalid_after_edit": "Cannot save: MCP server \"{{entry}}\" is missing required field \"{{field}}\" for its transport type.",
   "com_config_group_connection": "Connection",
   "com_config_group_authentication": "Authentication",
   "com_config_group_api_key": "API key",

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -675,6 +675,38 @@ describe('validateFieldValue', () => {
       expect(result.error.length).toBeGreaterThan(0);
     }
   });
+
+  it('validates a nested field reached through a union (header value must be string)', () => {
+    expect(
+      validateFieldValue('mcpServers.foo.headers.Authorization', 'Bearer xyz'),
+    ).toEqual({ success: true });
+    const bad = validateFieldValue('mcpServers.foo.headers.Authorization', 42);
+    expect(bad.success).toBe(false);
+  });
+});
+
+/* ---------------------------------------------------------------------------
+ * Regression — resolveSubSchema must keep walking through synthetic unions.
+ * The anyOfSchema wrapper used to drop _def.options, so the second segment
+ * after a multi-candidate union could not be resolved and validateFieldValue
+ * silently passed everything under unioned objects.
+ * -----------------------------------------------------------------------*/
+
+describe('resolveSubSchema — traversal through synthesized union', () => {
+  it('walks into a nested field after a union with multiple candidates', () => {
+    const schema = z3.object({
+      payload: z3.union([
+        z3.object({ headers: z3.record(z3.string(), z3.string()) }),
+        z3.object({ headers: z3.record(z3.string(), z3.string()) }),
+      ]),
+    });
+    const sub = resolveSubSchema(schema, ['payload', 'headers', 'Authorization']);
+    expect(sub).not.toBeNull();
+    const safeParse = (sub as { safeParse?: (v: unknown) => { success: boolean } }).safeParse;
+    expect(typeof safeParse).toBe('function');
+    expect(safeParse!('Bearer xyz').success).toBe(true);
+    expect(safeParse!(42).success).toBe(false);
+  });
 });
 
 /* ---------------------------------------------------------------------------

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -621,6 +621,62 @@ describe('validateFieldValue', () => {
     const result = validateFieldValue('interface', { privacyPolicy: {} });
     expect(result).toBeDefined();
   });
+
+  it('accepts streamable-http type for MCP server', () => {
+    expect(validateFieldValue('mcpServers.foo.type', 'streamable-http')).toEqual({ success: true });
+  });
+
+  it('accepts http type for MCP server', () => {
+    expect(validateFieldValue('mcpServers.foo.type', 'http')).toEqual({ success: true });
+  });
+
+  it('accepts stdio type for MCP server', () => {
+    expect(validateFieldValue('mcpServers.foo.type', 'stdio')).toEqual({ success: true });
+  });
+
+  it('rejects unknown type for MCP server', () => {
+    const result = validateFieldValue('mcpServers.foo.type', 'made-up-transport');
+    expect(result.success).toBe(false);
+  });
+
+  it('returns the most-specific branch on union failure (anyOfSchema heuristic)', () => {
+    const result = validateFieldValue('mcpServers.foo.type', 'made-up-transport');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const semicolonSplits = result.error.split(';');
+      // The most-specific branch is the literal-mismatch failure with a single
+      // issue, not the cumulative dump of every transport-branch failure.
+      expect(semicolonSplits.length).toBeLessThanOrEqual(2);
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('accepts https URL for MCP server (matches sse/streamable-http branches)', () => {
+    expect(validateFieldValue('mcpServers.foo.url', 'https://example.com/mcp')).toEqual({
+      success: true,
+    });
+  });
+
+  it('accepts ws URL for MCP server (matches websocket branch)', () => {
+    expect(validateFieldValue('mcpServers.foo.url', 'wss://example.com/mcp')).toEqual({
+      success: true,
+    });
+  });
+
+  it('rejects non-URL value for MCP server', () => {
+    const result = validateFieldValue('mcpServers.foo.url', 'not a url');
+    expect(result.success).toBe(false);
+  });
+
+  it('returns a single-branch error on union URL failure, not a concatenated dump', () => {
+    const result = validateFieldValue('mcpServers.foo.url', 'not a url');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const semicolonSplits = result.error.split(';');
+      expect(semicolonSplits.length).toBeLessThanOrEqual(2);
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+  });
 });
 
 /* ---------------------------------------------------------------------------
@@ -857,9 +913,8 @@ describe('YAML-editor fallback audit', () => {
  * Custom endpoint validation and schema extraction
  * -----------------------------------------------------------------------*/
 
-const ldpEndpoint = (
-  require3('librechat-data-provider') as { endpointSchema: ZodV3Schema }
-).endpointSchema;
+const ldpEndpoint = (require3('librechat-data-provider') as { endpointSchema: ZodV3Schema })
+  .endpointSchema;
 
 describe('custom endpoint schema', () => {
   const endpointTree = extractSchemaTree(ldpEndpoint);

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -644,8 +644,6 @@ describe('validateFieldValue', () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       const semicolonSplits = result.error.split(';');
-      // The most-specific branch is the literal-mismatch failure with a single
-      // issue, not the cumulative dump of every transport-branch failure.
       expect(semicolonSplits.length).toBeLessThanOrEqual(2);
       expect(result.error.length).toBeGreaterThan(0);
     }

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -841,6 +841,7 @@ export const getBaseConfigFn = createServerFn({ method: 'GET' }).handler(async (
   }
 
   let yamlMcpKeys: string[] | undefined;
+  let yamlMcpServers: Record<string, t.ConfigValue> | undefined;
   if (baseOnlyResponse.ok) {
     const { config: baseOnlyRaw } = (await baseOnlyResponse.json()) as {
       config: Record<string, t.ConfigValue>;
@@ -849,11 +850,19 @@ export const getBaseConfigFn = createServerFn({ method: 'GET' }).handler(async (
     const mcp = baseOnly.mcpServers;
     if (mcp && typeof mcp === 'object' && !Array.isArray(mcp)) {
       /** Trust the baseOnly response when it has a valid mcpServers shape. The previous byte-equality fallback against `config.mcpServers` was a defensive heuristic for hypothetical legacy backends that ignore `?baseOnly`, but it false-negatived whenever an admin override happened to be a no-op (e.g. an admin set `title` to a value that already matched YAML), causing the YAML lock affordances to disappear for entries that should stay locked. The deployed LibreChat supports `?baseOnly` directly, so the heuristic is no longer earning its keep. */
-      yamlMcpKeys = Object.keys(mcp as Record<string, t.ConfigValue>);
+      yamlMcpServers = mcp as Record<string, t.ConfigValue>;
+      yamlMcpKeys = Object.keys(yamlMcpServers);
     }
   }
 
-  return { config, dbOverrides, configuredFromBase, schemaDefaults: flatDefaults, yamlMcpKeys };
+  return {
+    config,
+    dbOverrides,
+    configuredFromBase,
+    schemaDefaults: flatDefaults,
+    yamlMcpKeys,
+    yamlMcpServers,
+  };
 });
 
 export const baseConfigOptions = queryOptions({

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -495,7 +495,8 @@ function anyOfSchema(candidates: t.ZodSchemaLike[]): t.ZodSchemaLike {
       error: best ?? { issues: [{ message: 'Validation failed', path: [] }] },
     };
   };
-  return { _def: { typeName: 'ZodUnion' }, safeParse } as t.ZodSchemaLike;
+  /** _def.options is preserved so resolveSubSchema can keep traversing into nested fields under union branches; without it, the next segment short-circuits and validateFieldValue silently passes everything. */
+  return { _def: { typeName: 'ZodUnion', options: candidates }, safeParse } as t.ZodSchemaLike;
 }
 
 /** Walks a Zod schema tree to find the sub-schema at a given dot-path.
@@ -530,10 +531,9 @@ export function resolveSubSchema(
       const options = unwrapped._def.options ?? [];
       const candidates: t.ZodSchemaLike[] = [];
       for (const opt of options) {
-        const optUnwrapped = unwrapSchema(opt);
-        if (optUnwrapped?.shape?.[segment]) {
-          candidates.push(optUnwrapped.shape[segment]);
-        }
+        /** Recurse so options that are records, arrays, or further unions resolve through their own walker case, not just shape lookup. */
+        const resolved = resolveSubSchema(opt, [segment]);
+        if (resolved) candidates.push(resolved);
       }
       if (candidates.length === 0) return null;
       if (candidates.length === 1) {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -848,17 +848,8 @@ export const getBaseConfigFn = createServerFn({ method: 'GET' }).handler(async (
     const baseOnly = normalizeAppServiceKeys(baseOnlyRaw);
     const mcp = baseOnly.mcpServers;
     if (mcp && typeof mcp === 'object' && !Array.isArray(mcp)) {
-      /** A LibreChat that predates the companion baseOnly support returns the same merged payload for both endpoints, so the response itself is not a reliable signal. When admin overrides on mcpServers exist (so we _expect_ baseOnly to be a strict subset of regular) but the two responses are byte-identical, treat the backend as legacy and fall back to "lock nothing" rather than locking admin-only servers. */
-      const mcpOverrides =
-        dbOverrides && typeof dbOverrides.mcpServers === 'object' && dbOverrides.mcpServers !== null
-          ? (dbOverrides.mcpServers as Record<string, t.ConfigValue>)
-          : null;
-      const hasMcpOverrides = !!mcpOverrides && Object.keys(mcpOverrides).length > 0;
-      const baseOnlyIsAuthoritative =
-        !hasMcpOverrides || JSON.stringify(mcp) !== JSON.stringify(config.mcpServers);
-      if (baseOnlyIsAuthoritative) {
-        yamlMcpKeys = Object.keys(mcp as Record<string, t.ConfigValue>);
-      }
+      /** Trust the baseOnly response when it has a valid mcpServers shape. The previous byte-equality fallback against `config.mcpServers` was a defensive heuristic for hypothetical legacy backends that ignore `?baseOnly`, but it false-negatived whenever an admin override happened to be a no-op (e.g. an admin set `title` to a value that already matched YAML), causing the YAML lock affordances to disappear for entries that should stay locked. The deployed LibreChat supports `?baseOnly` directly, so the heuristic is no longer earning its keep. */
+      yamlMcpKeys = Object.keys(mcp as Record<string, t.ConfigValue>);
     }
   }
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -453,11 +453,7 @@ export function getZodTypeName(
   return typeName || 'unknown';
 }
 
-/**
- * Builds a schema-like wrapper that accepts a value if any candidate's `safeParse`
- * accepts it. Avoids `z.union` so we don't tie callers to a specific zod major
- * version: candidates here may come from packages bundling an older zod release.
- */
+/** Synthesizes a union without z.union to avoid the zod v3/v4 cross-version pitfall. */
 function anyOfSchema(candidates: t.ZodSchemaLike[]): t.ZodSchemaLike {
   type ParseResult = {
     success: boolean;
@@ -482,15 +478,7 @@ function anyOfSchema(candidates: t.ZodSchemaLike[]): t.ZodSchemaLike {
       if (result.success) return { success: true };
       if (result.error) errors.push(result.error);
     }
-    /**
-     * Heuristic: when every branch failed, return the branch with the FEWEST
-     * issues. That's almost always the one the user was aiming at (a single
-     * typed field mismatch is more specific than a multi-field shape error),
-     * so it produces a much cleaner message than dumping all branch issues.
-     * Ties on issue count are broken by preferring the longest issue path
-     * (more specific to the user's input shape) so a remote-URL field doesn't
-     * fall back to the first branch's generic literal mismatch.
-     */
+    /** Pick the branch with the fewest issues (most likely the intended one); tiebreak on longest path. */
     const sorted = errors
       .filter((e): e is NonNullable<typeof e> => e != null && Array.isArray(e.issues))
       .sort((a, b) => {
@@ -507,13 +495,6 @@ function anyOfSchema(candidates: t.ZodSchemaLike[]): t.ZodSchemaLike {
       error: best ?? { issues: [{ message: 'Validation failed', path: [] }] },
     };
   };
-  /**
-   * SAFETY: We synthesize a partial ZodSchemaLike here that only implements
-   * safeParse + _def.typeName. validateFieldValue only invokes safeParse on
-   * the returned schema, so the partial shape is sufficient. We avoid
-   * constructing a real z.union to bypass the v3/v4 cross-version pitfall
-   * (configSchema bundles zod@3 while this file uses zod@4).
-   */
   return { _def: { typeName: 'ZodUnion' }, safeParse } as t.ZodSchemaLike;
 }
 
@@ -558,12 +539,6 @@ export function resolveSubSchema(
       if (candidates.length === 1) {
         current = candidates[0];
       } else {
-        /**
-         * Multiple union branches expose this field with potentially different schemas
-         * (e.g. MCPOptionsSchema's `type` is a different literal in each transport).
-         * Accept any of them by reconstructing a runtime union so per-field validation
-         * works without needing to pre-discriminate from sibling fields.
-         */
         current = anyOfSchema(candidates);
       }
     } else if (typeName === 'ZodIntersection') {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -926,7 +926,7 @@ export const saveBaseConfigFn = createServerFn({ method: 'POST' })
       entries: z
         .array(z.object({ fieldPath: safeFieldPath, value: z.unknown() }))
         .min(1)
-        .max(100),
+        .max(500),
     }),
   )
   .handler(async ({ data }) => {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -848,7 +848,17 @@ export const getBaseConfigFn = createServerFn({ method: 'GET' }).handler(async (
     const baseOnly = normalizeAppServiceKeys(baseOnlyRaw);
     const mcp = baseOnly.mcpServers;
     if (mcp && typeof mcp === 'object' && !Array.isArray(mcp)) {
-      yamlMcpKeys = Object.keys(mcp as Record<string, t.ConfigValue>);
+      /** A LibreChat that predates the companion baseOnly support returns the same merged payload for both endpoints, so the response itself is not a reliable signal. When admin overrides on mcpServers exist (so we _expect_ baseOnly to be a strict subset of regular) but the two responses are byte-identical, treat the backend as legacy and fall back to "lock nothing" rather than locking admin-only servers. */
+      const mcpOverrides =
+        dbOverrides && typeof dbOverrides.mcpServers === 'object' && dbOverrides.mcpServers !== null
+          ? (dbOverrides.mcpServers as Record<string, t.ConfigValue>)
+          : null;
+      const hasMcpOverrides = !!mcpOverrides && Object.keys(mcpOverrides).length > 0;
+      const baseOnlyIsAuthoritative =
+        !hasMcpOverrides || JSON.stringify(mcp) !== JSON.stringify(config.mcpServers);
+      if (baseOnlyIsAuthoritative) {
+        yamlMcpKeys = Object.keys(mcp as Record<string, t.ConfigValue>);
+      }
     }
   }
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -129,7 +129,6 @@ function inferRecordKVTypes(schema: t.ZodSchemaLike): t.KVValueType[] | undefine
   return types.size > 0 ? [...types] : undefined;
 }
 
-
 /** Merges fields from union object variants into a single list.
  *  When the same key appears in multiple variants with different literal
  *  types, the literals are combined into a union(literal(...) | literal(...))
@@ -454,6 +453,70 @@ export function getZodTypeName(
   return typeName || 'unknown';
 }
 
+/**
+ * Builds a schema-like wrapper that accepts a value if any candidate's `safeParse`
+ * accepts it. Avoids `z.union` so we don't tie callers to a specific zod major
+ * version: candidates here may come from packages bundling an older zod release.
+ */
+function anyOfSchema(candidates: t.ZodSchemaLike[]): t.ZodSchemaLike {
+  type ParseResult = {
+    success: boolean;
+    error?: { issues: Array<{ message: string; path: (string | number)[] }> };
+  };
+  const safeParse = (value: unknown): ParseResult => {
+    const errors: NonNullable<ParseResult['error']>[] = [];
+    for (const candidate of candidates) {
+      const c = candidate as t.ZodSchemaLike & {
+        safeParse?: (v: unknown) => ParseResult;
+      };
+      if (typeof c.safeParse !== 'function') continue;
+      let result: ParseResult;
+      try {
+        result = c.safeParse(value);
+      } catch (e) {
+        errors.push({
+          issues: [{ message: e instanceof Error ? e.message : 'Validation failed', path: [] }],
+        });
+        continue;
+      }
+      if (result.success) return { success: true };
+      if (result.error) errors.push(result.error);
+    }
+    /**
+     * Heuristic: when every branch failed, return the branch with the FEWEST
+     * issues. That's almost always the one the user was aiming at (a single
+     * typed field mismatch is more specific than a multi-field shape error),
+     * so it produces a much cleaner message than dumping all branch issues.
+     * Ties on issue count are broken by preferring the longest issue path
+     * (more specific to the user's input shape) so a remote-URL field doesn't
+     * fall back to the first branch's generic literal mismatch.
+     */
+    const sorted = errors
+      .filter((e): e is NonNullable<typeof e> => e != null && Array.isArray(e.issues))
+      .sort((a, b) => {
+        const ca = a.issues?.length ?? Infinity;
+        const cb = b.issues?.length ?? Infinity;
+        if (ca !== cb) return ca - cb;
+        const pa = Math.max(0, ...(a.issues ?? []).map((i) => i.path?.length ?? 0));
+        const pb = Math.max(0, ...(b.issues ?? []).map((i) => i.path?.length ?? 0));
+        return pb - pa;
+      });
+    const best = sorted[0];
+    return {
+      success: false,
+      error: best ?? { issues: [{ message: 'Validation failed', path: [] }] },
+    };
+  };
+  /**
+   * SAFETY: We synthesize a partial ZodSchemaLike here that only implements
+   * safeParse + _def.typeName. validateFieldValue only invokes safeParse on
+   * the returned schema, so the partial shape is sufficient. We avoid
+   * constructing a real z.union to bypass the v3/v4 cross-version pitfall
+   * (configSchema bundles zod@3 while this file uses zod@4).
+   */
+  return { _def: { typeName: 'ZodUnion' }, safeParse } as t.ZodSchemaLike;
+}
+
 /** Walks a Zod schema tree to find the sub-schema at a given dot-path.
  *  Returns the schema **with wrappers intact** so `.safeParse()` runs the
  *  full validation chain (refine, transform, pipe). Returns `null` if the
@@ -484,16 +547,25 @@ export function resolveSubSchema(
       current = valueType;
     } else if (typeName === 'ZodUnion') {
       const options = unwrapped._def.options ?? [];
-      let found: t.ZodSchemaLike | null = null;
+      const candidates: t.ZodSchemaLike[] = [];
       for (const opt of options) {
         const optUnwrapped = unwrapSchema(opt);
         if (optUnwrapped?.shape?.[segment]) {
-          found = optUnwrapped.shape[segment];
-          break;
+          candidates.push(optUnwrapped.shape[segment]);
         }
       }
-      if (!found) return null;
-      current = found;
+      if (candidates.length === 0) return null;
+      if (candidates.length === 1) {
+        current = candidates[0];
+      } else {
+        /**
+         * Multiple union branches expose this field with potentially different schemas
+         * (e.g. MCPOptionsSchema's `type` is a different literal in each transport).
+         * Accept any of them by reconstructing a runtime union so per-field validation
+         * works without needing to pre-discriminate from sibling fields.
+         */
+        current = anyOfSchema(candidates);
+      }
     } else if (typeName === 'ZodIntersection') {
       const resolved = resolveIntersection(unwrapped);
       if (!resolved?.shape?.[segment]) return null;
@@ -761,8 +833,9 @@ function normalizeAppServiceKeys(
 }
 
 export const getBaseConfigFn = createServerFn({ method: 'GET' }).handler(async () => {
-  const [baseResponse, dbBaseResponse] = await Promise.all([
+  const [baseResponse, baseOnlyResponse, dbBaseResponse] = await Promise.all([
     apiFetch('/api/admin/config/base'),
+    apiFetch('/api/admin/config/base?baseOnly=true'),
     apiFetch(`/api/admin/config/role/${BASE_CONFIG_PRINCIPAL_ID}`),
   ]);
 
@@ -792,7 +865,19 @@ export const getBaseConfigFn = createServerFn({ method: 'GET' }).handler(async (
     dbOverrides = dbConfig.overrides as Record<string, t.ConfigValue>;
   }
 
-  return { config, dbOverrides, configuredFromBase, schemaDefaults: flatDefaults };
+  let yamlMcpKeys: string[] | undefined;
+  if (baseOnlyResponse.ok) {
+    const { config: baseOnlyRaw } = (await baseOnlyResponse.json()) as {
+      config: Record<string, t.ConfigValue>;
+    };
+    const baseOnly = normalizeAppServiceKeys(baseOnlyRaw);
+    const mcp = baseOnly.mcpServers;
+    if (mcp && typeof mcp === 'object' && !Array.isArray(mcp)) {
+      yamlMcpKeys = Object.keys(mcp as Record<string, t.ConfigValue>);
+    }
+  }
+
+  return { config, dbOverrides, configuredFromBase, schemaDefaults: flatDefaults, yamlMcpKeys };
 });
 
 export const baseConfigOptions = queryOptions({
@@ -833,7 +918,10 @@ async function mergeIndexedArrayEntries(
     const segments = arrayPath.split('.');
     let current: unknown = baseConfig;
     for (const seg of segments) {
-      if (current == null || typeof current !== 'object') { current = undefined; break; }
+      if (current == null || typeof current !== 'object') {
+        current = undefined;
+        break;
+      }
       current = (current as Record<string, unknown>)[seg];
     }
     const arr = Array.isArray(current) ? [...current] : [];

--- a/src/server/scopes.ts
+++ b/src/server/scopes.ts
@@ -402,6 +402,51 @@ export const removeFieldProfileValueFn = createServerFn({ method: 'POST' })
   );
 
 /**
+ * Suppress an inherited field value for a specific scope.
+ */
+export const tombstoneFieldProfileValueFn = createServerFn({ method: 'POST' })
+  .inputValidator(
+    z.object({
+      fieldPath: safeFieldPath,
+      principalType: z.nativeEnum(PrincipalType),
+      principalId: z.string(),
+    }),
+  )
+  .handler(
+    async ({
+      data,
+    }: {
+      data: {
+        fieldPath: string;
+        principalType: PrincipalType;
+        principalId: string;
+      };
+    }) => {
+      if (isInterfacePermissionPath(data.fieldPath)) return { success: true };
+      await requireAnyCapability([
+        SystemCapabilities.ASSIGN_CONFIGS,
+        SystemCapabilities.MANAGE_CONFIGS,
+      ]);
+      const apiType = data.principalType;
+      const response = await apiFetch(
+        `/api/admin/config/${apiType}/${encodeURIComponent(data.principalId)}/fields/tombstone`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ fieldPath: data.fieldPath }),
+        },
+      );
+
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(
+          (err as { error?: string }).error ?? `Failed to tombstone field: ${response.status}`,
+        );
+      }
+      return { success: true };
+    },
+  );
+
+/**
  * Toggle a scope's isActive flag.
  */
 export const toggleScopeActiveFn = createServerFn({ method: 'POST' })

--- a/src/types/config-ui.ts
+++ b/src/types/config-ui.ts
@@ -84,6 +84,7 @@ export interface ConfigTabContentProps {
   sectionPermissions?: Record<string, { canView: boolean; canEdit: boolean }>;
   schemaDefaults?: FlatConfigMap;
   showConfiguredOnly?: boolean;
+  isEditingScope?: boolean;
   /** YAML-defined entry keys per section, keyed by parent path. */
   baseRecordKeys?: Record<string, Set<string>>;
   onValidationError?: (message: string) => void;
@@ -225,6 +226,7 @@ export interface FieldRendererProps {
   pendingResets?: Set<string>;
   schemaDefaults?: FlatConfigMap;
   showConfiguredOnly?: boolean;
+  isEditingScope?: boolean;
   /** When true, never strip labels via isSoleField.  Use when rendering a
    *  subset of fields within a larger section (e.g. priority fields). */
   alwaysShowLabels?: boolean;

--- a/src/types/config-ui.ts
+++ b/src/types/config-ui.ts
@@ -84,6 +84,12 @@ export interface ConfigTabContentProps {
   sectionPermissions?: Record<string, { canView: boolean; canEdit: boolean }>;
   schemaDefaults?: FlatConfigMap;
   showConfiguredOnly?: boolean;
+  /** Entry-key sets for record-type sections that come from the un-merged
+   *  YAML/file base config. Keyed by the section's parent path (e.g.
+   *  `mcpServers`). Record-type renderers use this to distinguish entries
+   *  whose identity is locked by YAML from entries that exist only via
+   *  admin overrides. */
+  baseRecordKeys?: Record<string, Set<string>>;
 }
 
 export interface ConfigTableOfContentsProps {
@@ -206,6 +212,10 @@ export interface FieldRendererProps {
   getValue: (path: string, fallback: ConfigValue) => ConfigValue;
   onChange: (path: string, value: ConfigValue) => void;
   onResetField?: (path: string) => void;
+  /** Current edited values map keyed by dot-path. Used by record-type custom
+   *  renderers to drive per-entry dirty state without re-deriving from
+   *  touchedPaths (which sticks even after edits revert to baseline). */
+  editedValues?: FlatConfigMap;
   disabled?: boolean;
   profileMap?: Record<string, string[]>;
   previewMode?: boolean;
@@ -224,6 +234,12 @@ export interface FieldRendererProps {
   /** When true, never strip labels via isSoleField.  Use when rendering a
    *  subset of fields within a larger section (e.g. priority fields). */
   alwaysShowLabels?: boolean;
+  /** Entry keys that come from the un-merged YAML/file base config for
+   *  the section currently being rendered. Record-type renderers (e.g.
+   *  MCP servers) use this to lock identity affordances (rename, delete)
+   *  for entries whose names originate in YAML, regardless of whether
+   *  admin overrides have been added on top of them. */
+  yamlBaseKeys?: Set<string>;
 }
 
 export interface ImportYamlDialogProps {

--- a/src/types/config-ui.ts
+++ b/src/types/config-ui.ts
@@ -87,6 +87,8 @@ export interface ConfigTabContentProps {
   /** YAML-defined entry keys per section, keyed by parent path. */
   baseRecordKeys?: Record<string, Set<string>>;
   onValidationError?: (message: string) => void;
+  /** True when editing a role/group scope rather than the base config; renderers may suppress structural actions (rename/delete of inherited entries) that can't be expressed without a scope-level tombstone. */
+  scopeMode?: boolean;
 }
 
 export interface ConfigTableOfContentsProps {
@@ -231,6 +233,8 @@ export interface FieldRendererProps {
   /** YAML-defined entry keys for the section being rendered. */
   yamlBaseKeys?: Set<string>;
   onValidationError?: (message: string) => void;
+  /** True when editing a role/group scope. Renderers that manage record entries should suppress rename/delete affordances because per-leaf saves alone can't tombstone an inherited entry. */
+  scopeMode?: boolean;
 }
 
 export interface ImportYamlDialogProps {

--- a/src/types/config-ui.ts
+++ b/src/types/config-ui.ts
@@ -90,6 +90,7 @@ export interface ConfigTabContentProps {
    *  whose identity is locked by YAML from entries that exist only via
    *  admin overrides. */
   baseRecordKeys?: Record<string, Set<string>>;
+  onValidationError?: (message: string) => void;
 }
 
 export interface ConfigTableOfContentsProps {
@@ -240,6 +241,7 @@ export interface FieldRendererProps {
    *  for entries whose names originate in YAML, regardless of whether
    *  admin overrides have been added on top of them. */
   yamlBaseKeys?: Set<string>;
+  onValidationError?: (message: string) => void;
 }
 
 export interface ImportYamlDialogProps {

--- a/src/types/config-ui.ts
+++ b/src/types/config-ui.ts
@@ -84,11 +84,7 @@ export interface ConfigTabContentProps {
   sectionPermissions?: Record<string, { canView: boolean; canEdit: boolean }>;
   schemaDefaults?: FlatConfigMap;
   showConfiguredOnly?: boolean;
-  /** Entry-key sets for record-type sections that come from the un-merged
-   *  YAML/file base config. Keyed by the section's parent path (e.g.
-   *  `mcpServers`). Record-type renderers use this to distinguish entries
-   *  whose identity is locked by YAML from entries that exist only via
-   *  admin overrides. */
+  /** YAML-defined entry keys per section, keyed by parent path. */
   baseRecordKeys?: Record<string, Set<string>>;
   onValidationError?: (message: string) => void;
 }
@@ -213,9 +209,6 @@ export interface FieldRendererProps {
   getValue: (path: string, fallback: ConfigValue) => ConfigValue;
   onChange: (path: string, value: ConfigValue) => void;
   onResetField?: (path: string) => void;
-  /** Current edited values map keyed by dot-path. Used by record-type custom
-   *  renderers to drive per-entry dirty state without re-deriving from
-   *  touchedPaths (which sticks even after edits revert to baseline). */
   editedValues?: FlatConfigMap;
   disabled?: boolean;
   profileMap?: Record<string, string[]>;
@@ -235,11 +228,7 @@ export interface FieldRendererProps {
   /** When true, never strip labels via isSoleField.  Use when rendering a
    *  subset of fields within a larger section (e.g. priority fields). */
   alwaysShowLabels?: boolean;
-  /** Entry keys that come from the un-merged YAML/file base config for
-   *  the section currently being rendered. Record-type renderers (e.g.
-   *  MCP servers) use this to lock identity affordances (rename, delete)
-   *  for entries whose names originate in YAML, regardless of whether
-   *  admin overrides have been added on top of them. */
+  /** YAML-defined entry keys for the section being rendered. */
   yamlBaseKeys?: Set<string>;
   onValidationError?: (message: string) => void;
 }

--- a/src/types/config-ui.ts
+++ b/src/types/config-ui.ts
@@ -87,8 +87,6 @@ export interface ConfigTabContentProps {
   /** YAML-defined entry keys per section, keyed by parent path. */
   baseRecordKeys?: Record<string, Set<string>>;
   onValidationError?: (message: string) => void;
-  /** True when editing a role/group scope rather than the base config; renderers may suppress structural actions (rename/delete of inherited entries) that can't be expressed without a scope-level tombstone. */
-  scopeMode?: boolean;
 }
 
 export interface ConfigTableOfContentsProps {
@@ -233,8 +231,6 @@ export interface FieldRendererProps {
   /** YAML-defined entry keys for the section being rendered. */
   yamlBaseKeys?: Set<string>;
   onValidationError?: (message: string) => void;
-  /** True when editing a role/group scope. Renderers that manage record entries should suppress rename/delete affordances because per-leaf saves alone can't tombstone an inherited entry. */
-  scopeMode?: boolean;
 }
 
 export interface ImportYamlDialogProps {


### PR DESCRIPTION
## Summary

I wired scoped MCP entry delete and rename flows to the durable LibreChat tombstone route so inherited MCP entries can be suppressed without brittle client-only unset behavior. This depends on https://github.com/danny-avila/LibreChat/pull/13534.

- Add a scope server function for `/api/admin/config/:principalType/:principalId/fields/tombstone`.
- Partition scoped resets so only whole `mcpServers.<entry>` paths become tombstones while leaf resets remain ordinary unsets.
- Pass scope editing context into the MCP renderer so scoped profiles can delete or rename inherited YAML entries while base YAML identity remains locked.
- Cover reset partitioning and scoped YAML identity affordances with focused tests.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `SESSION_SECRET=12345678901234567890123456789012 bun run test`
- `bun run lint`
- `SESSION_SECRET=12345678901234567890123456789012 bun run build`

### **Test Configuration**:

- macOS local workspace
- Bun/Vite admin-panel workspace

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes